### PR TITLE
Decoupling kv blockchain and its usage

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -279,6 +279,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
                0,
                "Port to be used to communicate with the diagnostic server using"
                "the concord-ctl script");
+  CONFIG_PARAM(kvBlockchainVersion, std::uint32_t, 1u, "Default version of KV blockchain for this replica");
 
   // Parameter to enable/disable waiting for transaction data to be persisted.
   // Not predefined configuration parameters
@@ -404,6 +405,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     serialize(outStream, enablePreProcessorMemoryPool);
     serialize(outStream, diagnosticsServerPort);
     serialize(outStream, useUnifiedCertificates);
+    serialize(outStream, kvBlockchainVersion);
   }
   void deserializeDataMembers(std::istream& inStream) {
     deserialize(inStream, isReadOnly);
@@ -503,6 +505,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
     deserialize(inStream, enablePreProcessorMemoryPool);
     deserialize(inStream, diagnosticsServerPort);
     deserialize(inStream, useUnifiedCertificates);
+    deserialize(inStream, kvBlockchainVersion);
   }
 
  private:
@@ -595,7 +598,8 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.operatorEnabled_,
               rc.enablePreProcessorMemoryPool,
               rc.diagnosticsServerPort,
-              rc.useUnifiedCertificates);
+              rc.useUnifiedCertificates,
+              rc.kvBlockchainVersion);
   os << ", ";
   for (auto& [param, value] : rc.config_params_) os << param << ": " << value << "\n";
   return os;

--- a/client/client_pool/test/client_pool_timer_test.cpp
+++ b/client/client_pool/test/client_pool_timer_test.cpp
@@ -25,7 +25,7 @@ using TestClient = std::shared_ptr<void>;
 
 TEST(client_pool_timer, work_items) {
   uint16_t num_times_called = 0;
-  std::chrono::milliseconds timeout = 1ms;
+  std::chrono::milliseconds timeout = 10ms;
   auto timer = Timer<TestClient>(timeout, [&num_times_called](TestClient&& c) -> void { num_times_called++; });
 
   // Wait for timeout

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -34,6 +34,13 @@ add_library(kvbc  src/ClientImp.cpp
     src/resources-manager/ReplicaResources.cpp
     src/resources-manager/AdaptivePruningManager.cpp
     src/resources-manager/IntervalMappingResourceManager.cpp
+
+    src/blockchain_misc.cpp
+    src/kvbc_adapter/state_snapshot_adapter.cpp
+    src/kvbc_adapter/kv_blockchain_adapter.cpp
+    src/kvbc_adapter/app_state_adapter.cpp
+    src/kvbc_adapter/blocks_deleter_adapter.cpp
+    src/kvbc_adapter/replica_adapter.cpp
 )
 
 if (BUILD_ROCKSDB_STORAGE)

--- a/kvbc/benchmark/kvbcbench/pre_execution.h
+++ b/kvbc/benchmark/kvbcbench/pre_execution.h
@@ -18,7 +18,7 @@
 
 #include "assertUtils.hpp"
 #include "categorization/block_merkle_category.h"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/replica_adapter.hpp"
 #include "input.h"
 
 namespace concord::kvbc::bench {
@@ -46,7 +46,7 @@ class PreExecutionSimulator {
   PreExecutionSimulator(const PreExecConfig& config,
                         const ReadKeys& merkle_read_keys,
                         const ReadKeys& versioned_read_keys,
-                        categorization::KeyValueBlockchain& kvbc)
+                        adapter::ReplicaBlockchain& kvbc)
       : config_(config), merkle_read_keys_(merkle_read_keys), versioned_read_keys_(versioned_read_keys), kvbc_(kvbc) {}
 
   void start() {
@@ -106,7 +106,7 @@ class PreExecutionSimulator {
   const ReadKeys& merkle_read_keys_;
   const ReadKeys& versioned_read_keys_;
 
-  categorization::KeyValueBlockchain& kvbc_;
+  adapter::ReplicaBlockchain& kvbc_;
 };
 
 }  // namespace concord::kvbc::bench

--- a/kvbc/include/Replica.h
+++ b/kvbc/include/Replica.h
@@ -11,7 +11,7 @@
 
 #include "st_reconfiguraion_sm.hpp"
 #include "OpenTracing.hpp"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/replica_adapter.hpp"
 #include "categorization/db_categories.h"
 #include "communication/ICommunication.hpp"
 #include "communication/CommFactory.hpp"
@@ -47,87 +47,89 @@ class Replica : public IReplica,
  public:
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IReplica implementation
-  Status start() override;
-  Status stop() override;
-  bool isRunning() const override { return (m_currentRepStatus == RepStatus::Running); }
-  RepStatus getReplicaStatus() const override;
-  const IReader &getReadOnlyStorage() const override;
-  BlockId addBlockToIdleReplica(categorization::Updates &&updates) override;
-  void set_command_handler(std::shared_ptr<ICommandsHandler> handler) override;
+  Status start() override final;
+  Status stop() override final;
+  bool isRunning() const override final { return (m_currentRepStatus == RepStatus::Running); }
+  RepStatus getReplicaStatus() const override final;
+  const IReader &getReadOnlyStorage() const override final;
+  BlockId addBlockToIdleReplica(categorization::Updates &&updates) override final;
+  void set_command_handler(std::shared_ptr<ICommandsHandler> handler) override final;
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IBlocksDeleter implementation
-  void deleteGenesisBlock() override;
-  BlockId deleteBlocksUntil(BlockId until) override;
+  void deleteGenesisBlock() override final;
+  BlockId deleteBlocksUntil(BlockId until) override final;
+  void deleteLastReachableBlock() override final;
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IReader
   std::optional<categorization::Value> get(const std::string &category_id,
                                            const std::string &key,
-                                           BlockId block_id) const override;
+                                           BlockId block_id) const override final;
 
-  std::optional<categorization::Value> getLatest(const std::string &category_id, const std::string &key) const override;
+  std::optional<categorization::Value> getLatest(const std::string &category_id,
+                                                 const std::string &key) const override final;
 
   void multiGet(const std::string &category_id,
                 const std::vector<std::string> &keys,
                 const std::vector<BlockId> &versions,
-                std::vector<std::optional<categorization::Value>> &values) const override;
+                std::vector<std::optional<categorization::Value>> &values) const override final;
 
   void multiGetLatest(const std::string &category_id,
                       const std::vector<std::string> &keys,
-                      std::vector<std::optional<categorization::Value>> &values) const override;
+                      std::vector<std::optional<categorization::Value>> &values) const override final;
 
   std::optional<categorization::TaggedVersion> getLatestVersion(const std::string &category_id,
-                                                                const std::string &key) const override;
+                                                                const std::string &key) const override final;
 
   void multiGetLatestVersion(const std::string &category_id,
                              const std::vector<std::string> &keys,
-                             std::vector<std::optional<categorization::TaggedVersion>> &versions) const override;
+                             std::vector<std::optional<categorization::TaggedVersion>> &versions) const override final;
 
-  std::optional<categorization::Updates> getBlockUpdates(BlockId block_id) const override;
+  std::optional<categorization::Updates> getBlockUpdates(BlockId block_id) const override final;
 
   // Get the current genesis block ID in the system.
-  BlockId getGenesisBlockId() const override;
+  BlockId getGenesisBlockId() const override final;
 
   // Get the last block ID in the system.
-  BlockId getLastBlockId() const override;
+  BlockId getLastBlockId() const override final;
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IBlockAdder
-  BlockId add(categorization::Updates &&) override;
+  BlockId add(categorization::Updates &&) override final;
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // IAppState implementation
-  bool hasBlock(BlockId blockId) const override;
+  bool hasBlock(BlockId blockId) const override final;
   bool getBlock(uint64_t blockId,
                 char *outBlock,
                 uint32_t outBlockMaxSize,
-                uint32_t *outBlockActualSize) const override;
+                uint32_t *outBlockActualSize) const override final;
   std::future<bool> getBlockAsync(uint64_t blockId,
                                   char *outBlock,
                                   uint32_t outBlockMaxSize,
-                                  uint32_t *outBlockActualSize) override;
-  bool getPrevDigestFromBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *) const override;
+                                  uint32_t *outBlockActualSize) override final;
+  bool getPrevDigestFromBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *) const override final;
   void getPrevDigestFromBlock(const char *blockData,
                               const uint32_t blockSize,
-                              bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const override;
+                              bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const override final;
   bool putBlock(const uint64_t blockId,
                 const char *blockData,
                 const uint32_t blockSize,
-                bool lastBlock = true) override;
+                bool lastBlock = true) override final;
   std::future<bool> putBlockAsync(uint64_t blockId,
                                   const char *block,
                                   const uint32_t blockSize,
-                                  bool lastblock) override;
-  uint64_t getLastReachableBlockNum() const override;
-  uint64_t getGenesisBlockNum() const override;
+                                  bool lastblock) override final;
+  uint64_t getLastReachableBlockNum() const override final;
+  uint64_t getGenesisBlockNum() const override final;
   // This method is used by state-transfer in order to find the latest block id in either the state-transfer chain or
   // the main blockchain
-  uint64_t getLastBlockNum() const override;
-  size_t postProcessUntilBlockId(uint64_t max_block_id) override;
+  uint64_t getLastBlockNum() const override final;
+  size_t postProcessUntilBlockId(uint64_t max_block_id) override final;
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   bool getBlockFromObjectStore(uint64_t blockId,
@@ -135,6 +137,9 @@ class Replica : public IReplica,
                                uint32_t outblockMaxSize,
                                uint32_t *outBlockSize) const;
   bool getPrevDigestFromObjectStoreBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *) const;
+  void getPrevDigestFromObjectStoreBlock(const char *blockData,
+                                         const uint32_t blockSize,
+                                         bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const;
   bool putBlockToObjectStore(const uint64_t blockId,
                              const char *blockData,
                              const uint32_t blockSize,
@@ -163,21 +168,18 @@ class Replica : public IReplica,
   void registerStBasedReconfigurationHandler(std::shared_ptr<concord::client::reconfiguration::IStateHandler>);
 
   std::shared_ptr<concord::storage::rocksdb::NativeClient> nativeDbClient() {
-    if (m_kvBlockchain) return m_kvBlockchain->db();
-    return nullptr;
+    return storage::rocksdb::NativeClient::fromIDBClient(m_dbSet.dataDBClient);
   }
 
-  std::optional<categorization::KeyValueBlockchain> &kvBlockchain() { return m_kvBlockchain; }
+  std::optional<adapter::ReplicaBlockchain> &kvBlockchain() { return op_kvBlockchain; }
 
-  void setStateSnapshotValueConverter(const categorization::KeyValueBlockchain::Converter &c) {
-    m_stateSnapshotValueConverter = c;
-  }
+  void setStateSnapshotValueConverter(const Converter &c) { m_stateSnapshotValueConverter = c; }
 
   void setLastApplicationTransactionTimeCallback(const LastApplicationTransactionTimeCallback &cb) {
     m_lastAppTxnCallback = cb;
   }
 
-  ~Replica() override;
+  virtual ~Replica();
 
  protected:
   RawBlock getBlockInternal(BlockId blockId) const;
@@ -227,9 +229,10 @@ class Replica : public IReplica,
   RepStatus m_currentRepStatus;
 
   concord::kvbc::IStorageFactory::DatabaseSet m_dbSet;
-  // The categorization KeyValueBlockchain is used for a normal read-write replica.
-  std::optional<categorization::KeyValueBlockchain> m_kvBlockchain;
-  categorization::KeyValueBlockchain::Converter m_stateSnapshotValueConverter{concord::kvbc::valueFromKvbcProto};
+  // The ReplicaBlockchain is used for a normal read-write replica.
+  std::optional<adapter::ReplicaBlockchain> op_kvBlockchain;
+  adapter::ReplicaBlockchain *m_kvBlockchain{nullptr};
+  Converter m_stateSnapshotValueConverter{concord::kvbc::valueFromKvbcProto};
   kvbc::LastApplicationTransactionTimeCallback m_lastAppTxnCallback{newestPublicEventGroupRecordTime};
   // The IdbAdapter instance is used for a read-only replica.
   std::unique_ptr<IDbAdapter> m_bcDbAdapter;
@@ -248,26 +251,27 @@ class Replica : public IReplica,
   const std::shared_ptr<concord::secretsmanager::ISecretsManagerImpl> secretsManager_;
   std::unique_ptr<concord::kvbc::StReconfigurationHandler> stReconfigurationSM_;
   std::shared_ptr<cron::CronTableRegistry> cronTableRegistry_{std::make_shared<cron::CronTableRegistry>()};
-  concord::util::ThreadPool blocksIOWorkersPool_;
   std::unique_ptr<concord::client::reconfiguration::ClientReconfigurationEngine> creEngine_;
   std::shared_ptr<concord::client::reconfiguration::IStateClient> creClient_;
   ReplicaResourceEntity replicaResources_;
+  concord::util::ThreadPool blocks_io_workers_pool;
   performance::AdaptivePruningManager AdaptivePruningManager_;
-
- private:
   struct Recorders {
     static constexpr uint64_t MAX_VALUE_MICROSECONDS = 2ULL * 1000ULL * 1000ULL;  // 2 seconds
-
+    const std::string component_ = "iappstate";
     Recorders() {
       auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-      registrar.perf.registerComponent("iappstate",
-                                       {get_block_duration, put_block_duration, delete_batch_blocks_duration});
+      if (!registrar.perf.isRegisteredComponent(component_)) {
+        registrar.perf.registerComponent(component_, {get_block_duration, put_block_duration});
+      }
     }
+
+    ~Recorders() {}
+
     DEFINE_SHARED_RECORDER(get_block_duration, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
     DEFINE_SHARED_RECORDER(put_block_duration, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
-    DEFINE_SHARED_RECORDER(
-        delete_batch_blocks_duration, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
   };
+  // All these recorders need to be shared
   Recorders histograms_;
 };  // namespace concord::kvbc
 

--- a/kvbc/include/block_metadata.hpp
+++ b/kvbc/include/block_metadata.hpp
@@ -44,8 +44,8 @@ class BlockMetadata : public IBlockMetadata {
   BlockMetadata(const IReader& storage) : IBlockMetadata(storage) {
     logger_ = logging::getLogger("skvbc.MetadataStorage");
   }
-  virtual uint64_t getLastBlockSequenceNum() const override;
-  virtual std::string serialize(uint64_t sequence_num) const override;
+  uint64_t getLastBlockSequenceNum() const override;
+  std::string serialize(uint64_t sequence_num) const override;
   static uint64_t getSequenceNum(const std::string& data);
 };
 

--- a/kvbc/include/blockchain_misc.hpp
+++ b/kvbc/include/blockchain_misc.hpp
@@ -1,0 +1,32 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <string>
+#include <functional>
+
+namespace concord::kvbc {
+enum BLOCKCHAIN_VERSION { CATEGORIZED_BLOCKCHAIN = 1, NATURAL_BLOCKCHAIN = 4 };
+
+// Key or value converter interface.
+// Allows users to convert keys or values to any format that is appropriate.
+using Converter = std::function<std::string(std::string &&)>;
+
+namespace bcutil {
+class BlockChainUtils {
+ public:
+  static std::string publicStateHashKey();
+};
+}  // namespace bcutil
+}  // end namespace concord::kvbc

--- a/kvbc/include/categorization/updates.h
+++ b/kvbc/include/categorization/updates.h
@@ -235,6 +235,8 @@ struct Updates {
 
   const CategoryInput& categoryUpdates() const { return category_updates_; }
 
+  CategoryInput&& categoryUpdates() { return std::move(category_updates_); }
+
   // Appends a key-value of an `Update` type to already existing key-values for that category.
   // Precondition: The given `category_id` is of the same type as the passed updates.
   // Returns true on success or false if the given `category_id` doesn't exist.
@@ -264,7 +266,6 @@ struct Updates {
 
  private:
   friend bool operator==(const Updates&, const Updates&);
-  friend class KeyValueBlockchain;
   CategoryInput category_updates_;
 };
 

--- a/kvbc/include/db_interfaces.h
+++ b/kvbc/include/db_interfaces.h
@@ -96,6 +96,10 @@ class IBlocksDeleter {
   // Throws on errors or if until <= genesis .
   virtual BlockId deleteBlocksUntil(BlockId until) = 0;
 
+  // This method should get the last block ID in the system and deletes it.
+  // The last block id is the latest block id.
+  virtual void deleteLastReachableBlock() = 0;
+
   virtual ~IBlocksDeleter() = default;
 };
 

--- a/kvbc/include/kvbc_adapter/app_state_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/app_state_adapter.hpp
@@ -1,0 +1,87 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "Logger.hpp"
+#include "thread_pool.hpp"
+#include "blockchain_misc.hpp"
+#include "kv_types.hpp"
+#include "rocksdb/native_client.h"
+#include "categorization/base_types.h"
+#include "categorization/updates.h"
+#include "categorized_kvbc_msgs.cmf.hpp"
+#include "ReplicaConfig.hpp"
+#include "db_interfaces.h"
+#include "categorization/kv_blockchain.h"
+#include "ReplicaResources.h"
+#include "replica_adapter_auxilliary_types.hpp"
+#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+
+using concord::storage::rocksdb::NativeClient;
+
+namespace concord::kvbc::adapter {
+
+class AppStateAdapter : public bftEngine::bcst::IAppState {
+ public:
+  virtual ~AppStateAdapter() { kvbc_ = nullptr; }
+  explicit AppStateAdapter(std::shared_ptr<concord::kvbc::categorization::KeyValueBlockchain> &kvbc);
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // IAppState implementation
+  bool hasBlock(BlockId blockId) const override final { return kvbc_->hasBlock(blockId); }
+  bool getBlock(uint64_t blockId,
+                char *outBlock,
+                uint32_t outBlockMaxSize,
+                uint32_t *outBlockActualSize) const override final;
+  std::future<bool> getBlockAsync(uint64_t blockId,
+                                  char *outBlock,
+                                  uint32_t outBlockMaxSize,
+                                  uint32_t *outBlockActualSize) override final {
+    // This function should never be called
+    ConcordAssert(false);
+    return std::async([]() { return false; });
+  }
+  bool getPrevDigestFromBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *) const override final;
+  void getPrevDigestFromBlock(const char *blockData,
+                              const uint32_t blockSize,
+                              bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const override final;
+  bool putBlock(const uint64_t blockId,
+                const char *blockData,
+                const uint32_t blockSize,
+                bool lastBlock = true) override final;
+  std::future<bool> putBlockAsync(uint64_t blockId,
+                                  const char *block,
+                                  const uint32_t blockSize,
+                                  bool lastblock) override final {
+    // This functions should not be called
+    ConcordAssert(false);
+    return std::async([]() { return false; });
+  }
+  uint64_t getLastReachableBlockNum() const override final { return kvbc_->getLastReachableBlockId(); }
+  uint64_t getGenesisBlockNum() const override final { return kvbc_->getGenesisBlockId(); }
+  // This method is used by state-transfer in order to find the latest block id in either the state-transfer chain or
+  // the main blockchain
+  uint64_t getLastBlockNum() const override final;
+  size_t postProcessUntilBlockId(uint64_t max_block_id) override final;
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+ private:
+  concord::kvbc::categorization::KeyValueBlockchain *kvbc_{nullptr};
+  logging::Logger logger_;
+};
+}  // namespace concord::kvbc::adapter

--- a/kvbc/include/kvbc_adapter/blocks_deleter_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/blocks_deleter_adapter.hpp
@@ -1,0 +1,74 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "Logger.hpp"
+#include "thread_pool.hpp"
+#include "blockchain_misc.hpp"
+#include "kv_types.hpp"
+#include "rocksdb/native_client.h"
+#include "categorization/base_types.h"
+#include "categorization/updates.h"
+#include "categorized_kvbc_msgs.cmf.hpp"
+#include "ReplicaConfig.hpp"
+#include "db_interfaces.h"
+#include "categorization/kv_blockchain.h"
+#include "ReplicaResources.h"
+#include "replica_adapter_auxilliary_types.hpp"
+
+using concord::storage::rocksdb::NativeClient;
+
+namespace concord::kvbc::adapter {
+
+class BlocksDeleterAdapter : public IBlocksDeleter {
+ public:
+  virtual ~BlocksDeleterAdapter() { kvbc_ = nullptr; }
+  explicit BlocksDeleterAdapter(std::shared_ptr<concord::kvbc::categorization::KeyValueBlockchain> &kvbc,
+                                const std::optional<aux::AdapterAuxTypes> &aux_types = std::nullopt);
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // IBlocksDeleter implementation
+  void deleteGenesisBlock() override final;
+  BlockId deleteBlocksUntil(BlockId until) override final;
+  void deleteLastReachableBlock() override final { return kvbc_->deleteLastReachableBlock(); }
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+ private:
+  concord::kvbc::categorization::KeyValueBlockchain *kvbc_{nullptr};
+  std::shared_ptr<concord::performance::ISystemResourceEntity> replica_resources_;
+
+  struct Recorders {
+    static constexpr uint64_t MAX_VALUE_MICROSECONDS = 2ULL * 1000ULL * 1000ULL;  // 2 seconds
+    const std::string component_ = "iblockdeleter";
+
+    Recorders() {
+      auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
+      if (!registrar.perf.isRegisteredComponent(component_)) {
+        registrar.perf.registerComponent(component_, {delete_batch_blocks_duration});
+      }
+    }
+
+    ~Recorders() {}
+
+    DEFINE_SHARED_RECORDER(
+        delete_batch_blocks_duration, 1, MAX_VALUE_MICROSECONDS, 3, concord::diagnostics::Unit::MICROSECONDS);
+  };
+  Recorders histograms_;
+};
+
+}  // namespace concord::kvbc::adapter

--- a/kvbc/include/kvbc_adapter/idempotent_reader.h
+++ b/kvbc/include/kvbc_adapter/idempotent_reader.h
@@ -15,20 +15,22 @@
 
 #include "assertUtils.hpp"
 #include "db_interfaces.h"
-#include "kv_blockchain.h"
+#include "replica_adapter.hpp"
 
 #include <memory>
 
-namespace concord::kvbc::categorization {
+namespace concord::kvbc::adapter {
 
 // A utility that adapts a KeyValueBlockchain instance to an IReader.
-class CategorizedReader : public IReader {
+class IdempotentReader : public IReader {
  public:
-  // Constructs a CategorizedReader from a non-null KeyValueBlockchain pointer.
+  // Constructs a IdempotentReader from a non-null KeyValueBlockchain pointer.
   // Precondition: kvbc != nullptr
-  CategorizedReader(const std::shared_ptr<const KeyValueBlockchain> &kvbc) : kvbc_{kvbc} {
+  IdempotentReader(const std::shared_ptr<const ReplicaBlockchain> &kvbc) : kvbc_{kvbc} {
     ConcordAssertNE(kvbc, nullptr);
   }
+
+  virtual ~IdempotentReader() = default;
 
  public:
   std::optional<categorization::Value> get(const std::string &category_id,
@@ -72,10 +74,10 @@ class CategorizedReader : public IReader {
 
   BlockId getGenesisBlockId() const override { return kvbc_->getGenesisBlockId(); }
 
-  BlockId getLastBlockId() const override { return kvbc_->getLastReachableBlockId(); }
+  BlockId getLastBlockId() const override { return kvbc_->getLastBlockId(); }
 
  private:
-  const std::shared_ptr<const KeyValueBlockchain> kvbc_;
+  const std::shared_ptr<const ReplicaBlockchain> kvbc_;
 };
 
-}  // namespace concord::kvbc::categorization
+}  // namespace concord::kvbc::adapter

--- a/kvbc/include/kvbc_adapter/kv_blockchain_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/kv_blockchain_adapter.hpp
@@ -1,0 +1,99 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "Logger.hpp"
+#include "blockchain_misc.hpp"
+#include "kv_types.hpp"
+#include "rocksdb/native_client.h"
+#include "categorization/base_types.h"
+#include "categorization/updates.h"
+#include "categorized_kvbc_msgs.cmf.hpp"
+#include "ReplicaConfig.hpp"
+#include "db_interfaces.h"
+#include "categorization/kv_blockchain.h"
+#include "ReplicaResources.h"
+#include "replica_adapter_auxilliary_types.hpp"
+
+using concord::storage::rocksdb::NativeClient;
+
+namespace concord::kvbc::adapter {
+
+class KeyValueBlockchain : public IReader, public IBlockAdder {
+ public:
+  virtual ~KeyValueBlockchain() { kvbc_ = nullptr; }
+  explicit KeyValueBlockchain(std::shared_ptr<concord::kvbc::categorization::KeyValueBlockchain> &kvbc);
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // IReader
+  std::optional<categorization::Value> get(const std::string &category_id,
+                                           const std::string &key,
+                                           BlockId block_id) const override final {
+    return kvbc_->get(category_id, key, block_id);
+  }
+
+  std::optional<categorization::Value> getLatest(const std::string &category_id,
+                                                 const std::string &key) const override final {
+    return kvbc_->getLatest(category_id, key);
+  }
+
+  void multiGet(const std::string &category_id,
+                const std::vector<std::string> &keys,
+                const std::vector<BlockId> &versions,
+                std::vector<std::optional<categorization::Value>> &values) const override final {
+    return kvbc_->multiGet(category_id, keys, versions, values);
+  }
+
+  void multiGetLatest(const std::string &category_id,
+                      const std::vector<std::string> &keys,
+                      std::vector<std::optional<categorization::Value>> &values) const override final {
+    return kvbc_->multiGetLatest(category_id, keys, values);
+  }
+
+  std::optional<categorization::TaggedVersion> getLatestVersion(const std::string &category_id,
+                                                                const std::string &key) const override final {
+    return kvbc_->getLatestVersion(category_id, key);
+  }
+
+  void multiGetLatestVersion(const std::string &category_id,
+                             const std::vector<std::string> &keys,
+                             std::vector<std::optional<categorization::TaggedVersion>> &versions) const override final {
+    return kvbc_->multiGetLatestVersion(category_id, keys, versions);
+  }
+
+  std::optional<categorization::Updates> getBlockUpdates(BlockId block_id) const override final {
+    return kvbc_->getBlockUpdates(block_id);
+  }
+
+  // Get the current genesis block ID in the system.
+  BlockId getGenesisBlockId() const override final { return kvbc_->getGenesisBlockId(); }
+
+  // Get the last block ID in the system.
+  BlockId getLastBlockId() const override final { return kvbc_->getLastReachableBlockId(); }
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // IBlockAdder
+  BlockId add(categorization::Updates &&updates) override final { return kvbc_->addBlock(std::move(updates)); }
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+ private:
+  concord::kvbc::categorization::KeyValueBlockchain *kvbc_{nullptr};
+};
+
+}  // namespace concord::kvbc::adapter

--- a/kvbc/include/kvbc_adapter/replica_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/replica_adapter.hpp
@@ -1,0 +1,219 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <type_traits>
+
+#include "assertUtils.hpp"
+
+#include "kv_types.hpp"
+#include "rocksdb/native_client.h"
+#include "blockchain_misc.hpp"
+#include "ReplicaConfig.hpp"
+#include "db_interfaces.h"
+#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+#include "state_snapshot_interface.hpp"
+#include "ISystemResourceEntity.hpp"
+#include "replica_adapter_auxilliary_types.hpp"
+#include "categorization/kv_blockchain.h"
+
+using concord::storage::rocksdb::NativeClient;
+
+namespace concord::kvbc::adapter {
+class ReplicaBlockchain : public IBlocksDeleter,
+                          public IReader,
+                          public IBlockAdder,
+                          public bftEngine::bcst::IAppState,
+                          public IKVBCStateSnapshot,
+                          public IDBCheckpoint {
+ public:
+  virtual ~ReplicaBlockchain();
+  explicit ReplicaBlockchain(
+      const std::shared_ptr<concord::storage::rocksdb::NativeClient> &native_client,
+      bool link_st_chain,
+      const std::optional<std::map<std::string, categorization::CATEGORY_TYPE>> &category_types = std::nullopt,
+      const std::optional<aux::AdapterAuxTypes> &aux_types = std::nullopt);
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // IBlocksDeleter implementation
+  void deleteGenesisBlock() override final { return deleter_->deleteGenesisBlock(); }
+  BlockId deleteBlocksUntil(BlockId until) override final { return deleter_->deleteBlocksUntil(until); }
+  void deleteLastReachableBlock() override final { return deleter_->deleteLastReachableBlock(); }
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // IReader
+  std::optional<categorization::Value> get(const std::string &category_id,
+                                           const std::string &key,
+                                           BlockId block_id) const override final {
+    return reader_->get(category_id, key, block_id);
+  }
+
+  std::optional<categorization::Value> getLatest(const std::string &category_id,
+                                                 const std::string &key) const override final {
+    return reader_->getLatest(category_id, key);
+  }
+
+  void multiGet(const std::string &category_id,
+                const std::vector<std::string> &keys,
+                const std::vector<BlockId> &versions,
+                std::vector<std::optional<categorization::Value>> &values) const override final {
+    return reader_->multiGet(category_id, keys, versions, values);
+  }
+
+  void multiGetLatest(const std::string &category_id,
+                      const std::vector<std::string> &keys,
+                      std::vector<std::optional<categorization::Value>> &values) const override final {
+    return reader_->multiGetLatest(category_id, keys, values);
+  }
+
+  std::optional<categorization::TaggedVersion> getLatestVersion(const std::string &category_id,
+                                                                const std::string &key) const override final {
+    return reader_->getLatestVersion(category_id, key);
+  }
+
+  void multiGetLatestVersion(const std::string &category_id,
+                             const std::vector<std::string> &keys,
+                             std::vector<std::optional<categorization::TaggedVersion>> &versions) const override final {
+    return reader_->multiGetLatestVersion(category_id, keys, versions);
+  }
+
+  std::optional<categorization::Updates> getBlockUpdates(BlockId block_id) const override final {
+    return reader_->getBlockUpdates(block_id);
+  }
+
+  // Get the current genesis block ID in the system.
+  BlockId getGenesisBlockId() const override final { return reader_->getGenesisBlockId(); }
+
+  // Get the last block ID in the system.
+  BlockId getLastBlockId() const override final { return reader_->getLastBlockId(); }
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // IBlockAdder
+  BlockId add(categorization::Updates &&updates) override final { return adder_->add(std::move(updates)); }
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // IAppState implementation
+  bool hasBlock(BlockId blockId) const override final { return app_state_->hasBlock(blockId); }
+  bool getBlock(uint64_t blockId,
+                char *outBlock,
+                uint32_t outBlockMaxSize,
+                uint32_t *outBlockActualSize) const override final {
+    return app_state_->getBlock(blockId, outBlock, outBlockMaxSize, outBlockActualSize);
+  }
+
+  std::future<bool> getBlockAsync(uint64_t blockId,
+                                  char *outBlock,
+                                  uint32_t outBlockMaxSize,
+                                  uint32_t *outBlockActualSize) override final {
+    ConcordAssert(false);
+    return std::async([]() { return false; });
+  }
+
+  bool getPrevDigestFromBlock(uint64_t blockId, bftEngine::bcst::StateTransferDigest *st_digest) const override final {
+    return app_state_->getPrevDigestFromBlock(blockId, st_digest);
+  }
+
+  void getPrevDigestFromBlock(const char *blockData,
+                              const uint32_t blockSize,
+                              bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const override final {
+    return app_state_->getPrevDigestFromBlock(blockData, blockSize, outPrevBlockDigest);
+  }
+
+  bool putBlock(const uint64_t blockId,
+                const char *blockData,
+                const uint32_t blockSize,
+                bool lastBlock = true) override final {
+    return app_state_->putBlock(blockId, blockData, blockSize, lastBlock);
+  }
+
+  std::future<bool> putBlockAsync(uint64_t blockId,
+                                  const char *block,
+                                  const uint32_t blockSize,
+                                  bool lastBlock) override final {
+    // This functions should not be called
+    ConcordAssert(false);
+    return std::async([]() { return false; });
+  }
+
+  uint64_t getLastReachableBlockNum() const override final { return app_state_->getLastReachableBlockNum(); }
+  uint64_t getGenesisBlockNum() const override final { return app_state_->getGenesisBlockNum(); }
+  // This method is used by state-transfer in order to find the latest block id in either the state-transfer chain or
+  // the main blockchain
+  uint64_t getLastBlockNum() const override final { return app_state_->getLastBlockNum(); }
+  size_t postProcessUntilBlockId(uint64_t max_block_id) override final {
+    return app_state_->postProcessUntilBlockId(max_block_id);
+  }
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  ////////////////////////////////////IKVBCStateSnapshot////////////////////////////////////////////////////////////////
+  void computeAndPersistPublicStateHash(
+      BlockId checkpoint_block_id,
+      const Converter &value_converter = [](std::string &&s) -> std::string { return std::move(s); }) override final {
+    state_snapshot_->computeAndPersistPublicStateHash(checkpoint_block_id, value_converter);
+  }
+
+  std::optional<PublicStateKeys> getPublicStateKeys() const override final {
+    return state_snapshot_->getPublicStateKeys();
+  }
+
+  void iteratePublicStateKeyValues(const std::function<void(std::string &&, std::string &&)> &f) const override final {
+    state_snapshot_->iteratePublicStateKeyValues(f);
+  }
+
+  bool iteratePublicStateKeyValues(const std::function<void(std::string &&, std::string &&)> &f,
+                                   const std::string &after_key) const override final {
+    return state_snapshot_->iteratePublicStateKeyValues(f, after_key);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  ////////////////////////////////////IDBCheckpoint/////////////////////////////////////////////////////////////////////
+  void trimBlocksFromCheckpoint(BlockId block_id_at_checkpoint) override final {
+    return db_chkpt_->trimBlocksFromCheckpoint(block_id_at_checkpoint);
+  }
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+ private:
+  void switch_to_rawptr();
+
+ private:
+  logging::Logger logger_;
+  //////////Common Interfaces /////////////////
+
+  ////////////////Set A of Unique Ptrs for better memory management ////////////////////////////////////////////////////
+  std::unique_ptr<IBlocksDeleter> up_deleter_;
+  std::unique_ptr<IReader> up_reader_;
+  std::unique_ptr<IBlockAdder> up_adder_;
+  std::unique_ptr<bftEngine::bcst::IAppState> up_app_state_;
+  std::unique_ptr<IKVBCStateSnapshot> up_state_snapshot_;
+  std::unique_ptr<IDBCheckpoint> up_db_chkpt_;
+
+  ////////////////Set A of Ptrs for better performance ////////////////////////////////////////////////////
+  IBlocksDeleter *deleter_{nullptr};
+  IReader *reader_{nullptr};
+  IBlockAdder *adder_{nullptr};
+  bftEngine::bcst::IAppState *app_state_{nullptr};
+  IKVBCStateSnapshot *state_snapshot_{nullptr};
+  IDBCheckpoint *db_chkpt_{nullptr};
+
+  //////////////Blockchain Abstractions //////////////////
+  std::shared_ptr<concord::kvbc::categorization::KeyValueBlockchain> kvbc_{nullptr};
+};
+}  // namespace concord::kvbc::adapter

--- a/kvbc/include/kvbc_adapter/replica_adapter_auxilliary_types.hpp
+++ b/kvbc/include/kvbc_adapter/replica_adapter_auxilliary_types.hpp
@@ -1,0 +1,32 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "Metrics.hpp"
+#include "ISystemResourceEntity.hpp"
+
+namespace concord::kvbc::adapter::aux {
+
+struct AdapterAuxTypes {
+  explicit AdapterAuxTypes(std::shared_ptr<concordMetrics::Aggregator> aggregator,
+                           concord::performance::ISystemResourceEntity& resource_entity)
+      : aggregator_(aggregator), resource_entity_(resource_entity) {}
+  std::shared_ptr<concordMetrics::Aggregator> aggregator_;
+  concord::performance::ISystemResourceEntity& resource_entity_;
+};
+
+}  // namespace concord::kvbc::adapter::aux

--- a/kvbc/include/kvbc_adapter/state_snapshot_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/state_snapshot_adapter.hpp
@@ -1,0 +1,66 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <string>
+#include <type_traits>
+
+#include "categorization/base_types.h"
+#include "categorization/updates.h"
+#include "categorized_kvbc_msgs.cmf.hpp"
+#include "state_snapshot_interface.hpp"
+#include "categorization/kv_blockchain.h"
+#include "rocksdb/native_client.h"
+#include "ReplicaConfig.hpp"
+
+using concord::storage::rocksdb::NativeClient;
+using concord::kvbc::IKVBCStateSnapshot;
+
+namespace concord::kvbc::adapter::statesnapshot {
+class KVBCStateSnapshot : public IKVBCStateSnapshot, public IDBCheckpoint {
+ public:
+  explicit KVBCStateSnapshot(std::shared_ptr<concord::kvbc::categorization::KeyValueBlockchain>& kvbc);
+
+  ////////////////////////////IKVBCStateSnapshot////////////////////////////////////////////////////////////////////////
+  void computeAndPersistPublicStateHash(
+      BlockId checkpoint_block_id,
+      const Converter& value_converter = [](std::string&& s) -> std::string { return std::move(s); }) override final {
+    return kvbc_->computeAndPersistPublicStateHash(checkpoint_block_id, value_converter);
+  }
+
+  std::optional<PublicStateKeys> getPublicStateKeys() const override final { return kvbc_->getPublicStateKeys(); }
+
+  void iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f) const override final {
+    return kvbc_->iteratePublicStateKeyValues(f);
+  }
+
+  bool iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f,
+                                   const std::string& after_key) const override final {
+    return kvbc_->iteratePublicStateKeyValues(f, after_key);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  /////////////////////////////////IDBCheckpoint////////////////////////////////////////////////////////////////////////
+  void trimBlocksFromCheckpoint(BlockId block_id_at_checkpoint) override final {
+    return kvbc_->trimBlocksFromSnapshot(block_id_at_checkpoint);
+  }
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  virtual ~KVBCStateSnapshot() { kvbc_ = nullptr; }
+
+ private:
+  concord::kvbc::categorization::KeyValueBlockchain* kvbc_{nullptr};
+};
+}  // end of namespace concord::kvbc::adapter::statesnapshot

--- a/kvbc/include/metadata_block_id.h
+++ b/kvbc/include/metadata_block_id.h
@@ -13,7 +13,7 @@
 #pragma once
 
 #include "assertUtils.hpp"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/replica_adapter.hpp"
 #include "endianness.hpp"
 #include "kv_types.hpp"
 #include "PersistentStorage.hpp"
@@ -25,9 +25,9 @@ namespace concord::kvbc {
 
 // Persist the last KVBC block ID in big-endian in metadata's user data field.
 template <bool in_transaction>
-void persistLastBlockIdInMetadata(const categorization::KeyValueBlockchain &blockchain,
+void persistLastBlockIdInMetadata(const adapter::ReplicaBlockchain &blockchain,
                                   const std::shared_ptr<bftEngine::impl::PersistentStorage> &metadata) {
-  const auto user_data = concordUtils::toBigEndianArrayBuffer(blockchain.getLastReachableBlockId());
+  const auto user_data = concordUtils::toBigEndianArrayBuffer(blockchain.getLastBlockId());
   if constexpr (in_transaction) {
     metadata->setUserDataInTransaction(user_data.data(), user_data.size());
   } else {

--- a/kvbc/include/reconfiguration_kvbc_handler.hpp
+++ b/kvbc/include/reconfiguration_kvbc_handler.hpp
@@ -15,12 +15,12 @@
 #include "ReplicaConfig.hpp"
 #include "reconfiguration/ireconfiguration.hpp"
 #include "db_interfaces.h"
+#include "blockchain_misc.hpp"
 #include "hex_tools.h"
 #include "block_metadata.hpp"
 #include "kvbc_key_types.hpp"
 #include "SigManager.hpp"
 #include "reconfiguration/reconfiguration_handler.hpp"
-#include "categorization/kv_blockchain.h"
 #include "kvbc_app_filter/value_from_kvbc_proto.h"
 #include "AdaptivePruningManager.hpp"
 #include "IntervalMappingResourceManager.hpp"
@@ -56,7 +56,7 @@ class StateSnapshotReconfigurationHandler : public ReconfigurationBlockTools,
  public:
   StateSnapshotReconfigurationHandler(kvbc::IBlockAdder& block_adder,
                                       kvbc::IReader& ro_storage,
-                                      const categorization::KeyValueBlockchain::Converter& state_value_converter,
+                                      const Converter& state_value_converter,
                                       const kvbc::LastApplicationTransactionTimeCallback& last_app_txn_time_cb_)
       : ReconfigurationBlockTools{block_adder, ro_storage},
         state_value_converter_{state_value_converter},
@@ -97,7 +97,7 @@ class StateSnapshotReconfigurationHandler : public ReconfigurationBlockTools,
  private:
   // Allows users to convert state values to any format that is appropriate.
   // The default converter extracts the value from the ValueWithTrids protobuf type.
-  categorization::KeyValueBlockchain::Converter state_value_converter_{valueFromKvbcProto};
+  Converter state_value_converter_{valueFromKvbcProto};
 
   // Return the time of the last application-level transaction stored in the blockchain.
   // The result must be a string that can be parsed via google::protobuf::util::TimeUtil::FromString().

--- a/kvbc/include/replica_state_sync.h
+++ b/kvbc/include/replica_state_sync.h
@@ -18,7 +18,7 @@
 #include "storage/db_types.h"
 #include "Logger.hpp"
 #include "db_adapter_interface.h"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/replica_adapter.hpp"
 #include "PersistentStorage.hpp"
 
 #include <memory>
@@ -33,7 +33,7 @@ class ReplicaStateSync {
 
   // Synchronizes replica state and returns a number of deleted blocks.
   virtual uint64_t execute(logging::Logger& logger,
-                           categorization::KeyValueBlockchain& blockchain,
+                           adapter::ReplicaBlockchain& blockchain,
                            const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                            uint64_t lastExecutedSeqNum,
                            uint32_t maxNumOfBlocksToDelete) = 0;

--- a/kvbc/include/replica_state_sync_imp.hpp
+++ b/kvbc/include/replica_state_sync_imp.hpp
@@ -26,18 +26,18 @@ class ReplicaStateSyncImp : public ReplicaStateSync {
   ~ReplicaStateSyncImp() override = default;
 
   uint64_t execute(logging::Logger& logger,
-                   categorization::KeyValueBlockchain& blockchain,
+                   adapter::ReplicaBlockchain& blockchain,
                    const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                    uint64_t lastExecutedSeqNum,
                    uint32_t maxNumOfBlocksToDelete) override;
 
   uint64_t executeBasedOnBftSeqNum(logging::Logger& logger,
-                                   categorization::KeyValueBlockchain& blockchain,
+                                   adapter::ReplicaBlockchain& blockchain,
                                    uint64_t lastExecutedSeqNum,
                                    uint32_t maxNumOfBlocksToDelete);
 
   uint64_t executeBasedOnBlockId(logging::Logger& logger,
-                                 categorization::KeyValueBlockchain& blockchain,
+                                 adapter::ReplicaBlockchain& blockchain,
                                  const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                                  uint32_t maxNumOfBlocksToDelete);
 

--- a/kvbc/include/state_snapshot_interface.hpp
+++ b/kvbc/include/state_snapshot_interface.hpp
@@ -1,0 +1,75 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+#include <optional>
+#include <functional>
+#include <string>
+
+#include "kv_types.hpp"
+#include "categorized_kvbc_msgs.cmf.hpp"
+#include "blockchain_misc.hpp"
+
+using concord::kvbc::categorization::PublicStateKeys;
+
+namespace concord::kvbc {
+
+class IDBCheckpoint {
+ public:
+  // Trims the DB snapshot such that its last reachable block is equal to `block_id_at_checkpoint`.
+  // This method is supposed to be called on DB snapshots only and not on the actual blockchain.
+  // Precondition1: The current KeyValueBlockchain instance points to a DB snapshot.
+  // Precondition2: `block_id_at_checkpoint` >= INITIAL_GENESIS_BLOCK_ID
+  // Precondition3: `block_id_at_checkpoint` <= getLastReachableBlockId()
+  virtual void trimBlocksFromCheckpoint(BlockId block_id_at_checkpoint) = 0;
+
+  virtual ~IDBCheckpoint() = default;
+};
+
+// State snapshot support.
+class IKVBCStateSnapshot {
+ public:
+  // Computes and persists the public state hash by:
+  //  h0 = hash("")
+  //  h1 = hash(h0 || hash(k1) || v1)
+  //  h2 = hash(h1 || hash(k2) || v2)
+  //  ...
+  //  hN = hash(hN-1 || hash(kN) || vN)
+  //
+  // This method is supposed to be called on DB snapshots only and not on the actual blockchain.
+  // Precondition: The current KeyValueBlockchain instance points to a DB snapshot.
+  virtual void computeAndPersistPublicStateHash(BlockId checkpoint_block_id, const Converter& value_converter) = 0;
+
+  // Returns the public state keys as of the current point in the blockchain's history.
+  // Returns std::nullopt if no public keys have been persisted.
+  virtual std::optional<PublicStateKeys> getPublicStateKeys() const = 0;
+
+  // Iterate over all public key values, calling the given function multiple times with two parameters:
+  // * key
+  // * value
+  virtual void iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f) const = 0;
+
+  // Iterate over public key values from the key after `after_key`, calling the given function multiple times with two
+  // parameters:
+  // * key
+  // * value
+  //
+  // If `after_key` is not a public key, false is returned and no iteration is done (no calls to `f`). Else, iteration
+  // is done and the returned value is true, even if there are 0 public keys to actually iterate.
+  virtual bool iteratePublicStateKeyValues(const std::function<void(std::string&&, std::string&&)>& f,
+                                           const std::string& after_key) const = 0;
+
+  virtual ~IKVBCStateSnapshot() = default;
+};
+
+}  // namespace concord::kvbc

--- a/kvbc/src/Replica.cpp
+++ b/kvbc/src/Replica.cpp
@@ -2,36 +2,29 @@
 //
 // KV Blockchain replica implementation.
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include "Replica.h"
 #include <inttypes.h>
-#include <algorithm>
-#include <cassert>
-#include <chrono>
-#include <cstdlib>
 #include <exception>
 #include <string_view>
 #include <utility>
 #include "assertUtils.hpp"
 #include "endianness.hpp"
+#include "json_output.hpp"
 #include "communication/CommDefs.hpp"
 #include "kv_types.hpp"
-#include "hex_tools.h"
 #include "replica_state_sync.h"
 #include "sliver.hpp"
 #include "metadata_block_id.h"
 #include "bftengine/DbMetadataStorage.hpp"
 #include "rocksdb/native_client.h"
+#include "categorization/blocks.h"
 #include "pruning_handler.hpp"
 #include "IRequestHandler.hpp"
 #include "RequestHandler.h"
 #include "reconfiguration_kvbc_handler.hpp"
 #include "st_reconfiguraion_sm.hpp"
 #include "bftengine/ControlHandler.hpp"
-#include "throughput.hpp"
 #include "bftengine/EpochManager.hpp"
 #include "bftengine/ReconfigurationCmd.hpp"
 #include "client/reconfiguration/st_based_reconfiguration_client.hpp"
@@ -127,7 +120,7 @@ class KvbcRequestHandler : public bftEngine::RequestHandler {
   static std::shared_ptr<KvbcRequestHandler> create(
       const std::shared_ptr<IRequestsHandler> &user_req_handler,
       const std::shared_ptr<concord::cron::CronTableRegistry> &cron_table_registry,
-      categorization::KeyValueBlockchain &blockchain,
+      adapter::ReplicaBlockchain &blockchain,
       std::shared_ptr<concordMetrics::Aggregator> aggregator_,
       ISystemResourceEntity &resourceEntity) {
     return std::shared_ptr<KvbcRequestHandler>{
@@ -149,7 +142,7 @@ class KvbcRequestHandler : public bftEngine::RequestHandler {
  private:
   KvbcRequestHandler(const std::shared_ptr<IRequestsHandler> &user_req_handler,
                      const std::shared_ptr<concord::cron::CronTableRegistry> &cron_table_registry,
-                     categorization::KeyValueBlockchain &blockchain,
+                     adapter::ReplicaBlockchain &blockchain,
                      std::shared_ptr<concordMetrics::Aggregator> aggregator_,
                      ISystemResourceEntity &resourceEntity)
       : bftEngine::RequestHandler(resourceEntity, aggregator_), blockchain_{blockchain} {
@@ -164,7 +157,7 @@ class KvbcRequestHandler : public bftEngine::RequestHandler {
 
  private:
   std::shared_ptr<bftEngine::impl::PersistentStorage> persistent_storage_;
-  categorization::KeyValueBlockchain &blockchain_;
+  adapter::ReplicaBlockchain &blockchain_;
 };
 void Replica::registerReconfigurationHandlers(std::shared_ptr<bftEngine::IRequestsHandler> requestHandler) {
   requestHandler->setReconfigurationHandler(std::make_shared<kvbc::reconfiguration::ReconfigurationHandler>(
@@ -303,7 +296,7 @@ void Replica::saveReconfigurationCmdToResPages(const std::string &key) {
 }
 
 void Replica::createReplicaAndSyncState() {
-  ConcordAssert(m_kvBlockchain.has_value());
+  ConcordAssertNE(m_kvBlockchain, nullptr);
   auto requestHandler =
       KvbcRequestHandler::create(m_cmdHandler, cronTableRegistry_, *m_kvBlockchain, aggregator_, replicaResources_);
   registerReconfigurationHandlers(requestHandler);
@@ -356,8 +349,8 @@ void Replica::createReplicaAndSyncState() {
         auto db = storage::rocksdb::NativeClient::newClient(
             path, read_only, storage::rocksdb::NativeClient::DefaultOptions{});
         const auto link_st_chain = false;
-        auto kvbc = categorization::KeyValueBlockchain{db, link_st_chain};
-        kvbc.trimBlocksFromSnapshot(block_id_at_checkpoint);
+        auto kvbc = adapter::ReplicaBlockchain{db, link_st_chain};
+        kvbc.trimBlocksFromCheckpoint(block_id_at_checkpoint);
         kvbc.computeAndPersistPublicStateHash(block_id_at_checkpoint, value_converter);
       });
 }
@@ -381,26 +374,12 @@ BlockId Replica::addBlockToIdleReplica(categorization::Updates &&updates) {
     throw std::logic_error{"addBlockToIdleReplica() called on a non-idle replica"};
   }
 
-  return m_kvBlockchain->addBlock(std::move(updates));
+  return m_kvBlockchain->add(std::move(updates));
 }
 
-void Replica::deleteGenesisBlock() {
-  const auto genesisBlock = m_kvBlockchain->getGenesisBlockId();
-  if (genesisBlock == 0) {
-    throw std::logic_error{"Cannot delete the genesis block from an empty blockchain"};
-  }
-  m_kvBlockchain->deleteBlock(genesisBlock);
-}
+void Replica::deleteGenesisBlock() { return m_kvBlockchain->deleteGenesisBlock(); }
 
 BlockId Replica::deleteBlocksUntil(BlockId until) {
-  ISystemResourceEntity::scopedDurMeasurment mes(replicaResources_, ISystemResourceEntity::type::pruning_utilization);
-  const auto genesisBlock = m_kvBlockchain->getGenesisBlockId();
-  if (genesisBlock == 0) {
-    throw std::logic_error{"Cannot delete a block range from an empty blockchain"};
-  } else if (until <= genesisBlock) {
-    throw std::invalid_argument{"Invalid 'until' value passed to deleteBlocksUntil()"};
-  }
-
   // Inform State Transfer about pruning. We must do it in this thread context for persistency considerations, and in
   // this layer to lower the chance for bugs (there are multiple callers to this function), in which pruning is not
   // notified to ST. In that case, ST state will be corrupted.
@@ -408,24 +387,15 @@ BlockId Replica::deleteBlocksUntil(BlockId until) {
     // We assume until > 0, see check above
     m_stateTransfer->reportLastAgreedPrunableBlockId(until - 1);
   }
-
-  const auto lastReachableBlock = m_kvBlockchain->getLastReachableBlockId();
-  const auto lastDeletedBlock = std::min(lastReachableBlock, until - 1);
-  const auto start = std::chrono::steady_clock::now();
-  for (auto i = genesisBlock; i <= lastDeletedBlock; ++i) {
-    ISystemResourceEntity::scopedDurMeasurment mes(replicaResources_,
-                                                   ISystemResourceEntity::type::pruning_avg_time_micro);
-    ConcordAssert(m_kvBlockchain->deleteBlock(i));
-  }
-  auto jobDuration =
-      std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count();
-  histograms_.delete_batch_blocks_duration->recordAtomic(jobDuration);
-  return lastDeletedBlock;
+  ISystemResourceEntity::scopedDurMeasurment mes(replicaResources_, ISystemResourceEntity::type::pruning_utilization);
+  return m_kvBlockchain->deleteBlocksUntil(until);
 }
+
+void Replica::deleteLastReachableBlock() { return m_kvBlockchain->deleteLastReachableBlock(); }
 
 BlockId Replica::add(categorization::Updates &&updates) {
   replicaResources_.addMeasurement({ISystemResourceEntity::type::add_blocks_accumulated, 1, 0, 0});
-  return m_kvBlockchain->addBlock(std::move(updates));
+  return m_kvBlockchain->add(std::move(updates));
 }
 
 std::optional<categorization::Value> Replica::get(const std::string &category_id,
@@ -475,7 +445,7 @@ BlockId Replica::getLastBlockId() const {
   if (replicaConfig_.isReadOnly) {
     return m_bcDbAdapter->getLastReachableBlockId();
   }
-  return m_kvBlockchain->getLastReachableBlockId();
+  return m_kvBlockchain->getLastBlockId();
 }
 
 void Replica::set_command_handler(std::shared_ptr<ICommandsHandler> handler) { m_cmdHandler = handler; }
@@ -497,8 +467,8 @@ Replica::Replica(ICommunication *comm,
       aggregator_(aggregator),
       pm_{pm},
       secretsManager_{secretsManager},
-      blocksIOWorkersPool_((replicaConfig.numWorkerThreadsForBlockIO > 0) ? replicaConfig.numWorkerThreadsForBlockIO
-                                                                          : std::thread::hardware_concurrency()),
+      blocks_io_workers_pool((replicaConfig.numWorkerThreadsForBlockIO > 0) ? replicaConfig.numWorkerThreadsForBlockIO
+                                                                            : std::thread::hardware_concurrency()),
       AdaptivePruningManager_{
           concord::performance::IntervalMappingResourceManager::createIntervalMappingResourceManager(
               replicaResources_,
@@ -586,17 +556,35 @@ Replica::Replica(ICommunication *comm,
         throw std::invalid_argument{msg};
       }
     }
-    m_kvBlockchain.emplace(
-        storage::rocksdb::NativeClient::fromIDBClient(m_dbSet.dataDBClient), linkStChain, kvbc_categories);
-    m_kvBlockchain->setAggregator(aggregator);
-
+    op_kvBlockchain.emplace(storage::rocksdb::NativeClient::fromIDBClient(m_dbSet.dataDBClient),
+                            linkStChain,
+                            kvbc_categories,
+                            concord::kvbc::adapter::aux::AdapterAuxTypes(this->aggregator_, this->replicaResources_));
+    m_kvBlockchain = &(op_kvBlockchain.value());
+    LOG_INFO(logger, "ARC06: Replica::REPLICA" << KVLOG(this, m_kvBlockchain));
     auto &registrar = concord::diagnostics::RegistrarSingleton::getInstance();
-    concord::diagnostics::StatusHandler handler(
-        "pruning", "Pruning Status", [this]() { return m_kvBlockchain->getPruningStatus(); });
+    concord::diagnostics::StatusHandler handler("pruning", "Pruning Status", [this]() {
+      std::ostringstream oss;
+      std::unordered_map<std::string, std::string> result;
+      result.insert(
+          concordUtils::toPair("versionedNumOfDeletedKeys",
+                               aggregator_->GetCounter("kv_blockchain_deletes", "numOfVersionedKeysDeleted").Get()));
+      result.insert(
+          concordUtils::toPair("immutableNumOfDeletedKeys",
+                               aggregator_->GetCounter("kv_blockchain_deletes", "numOfImmutableKeysDeleted").Get()));
+      result.insert(concordUtils::toPair(
+          "merkleNumOfDeletedKeys", aggregator_->GetCounter("kv_blockchain_deletes", "numOfMerkleKeysDeleted").Get()));
+      result.insert(concordUtils::toPair("getGenesisBlockId()", getGenesisBlockId()));
+      result.insert(concordUtils::toPair("getLastReachableBlockId()", getLastBlockId()));
+      result.insert(concordUtils::toPair("isPruningInProgress",
+                                         bftEngine::ControlStateManager::instance().getPruningProcessStatus()));
+      oss << concordUtils::kContainerToJson(result);
+      return oss.str();
+    });
     registrar.status.registerHandler(handler);
   }
-  m_dbSet.dataDBClient->setAggregator(aggregator);
-  m_dbSet.metadataDBClient->setAggregator(aggregator);
+  m_dbSet.dataDBClient->setAggregator(aggregator_);
+  m_dbSet.metadataDBClient->setAggregator(aggregator_);
   auto stKeyManipulator = std::shared_ptr<storage::ISTKeyManipulator>{storageFactory->newSTKeyManipulator()};
   m_stateTransfer = bftEngine::bcst::create(stConfig, this, m_metadataDBClient, stKeyManipulator, aggregator_);
   if (!replicaConfig.isReadOnly) {
@@ -620,6 +608,9 @@ Replica::~Replica() {
     }
   }
   if (creEngine_) creEngine_->stop();
+  if (m_kvBlockchain) {
+    m_kvBlockchain = nullptr;
+  }
 }
 
 /*
@@ -630,26 +621,7 @@ bool Replica::putBlock(const uint64_t blockId, const char *blockData, const uint
   if (replicaConfig_.isReadOnly) {
     return putBlockToObjectStore(blockId, blockData, blockSize, lastBlock);
   }
-
-  auto view = std::string_view{blockData, blockSize};
-  const auto rawBlock = categorization::RawBlock::deserialize(view);
-  if (m_kvBlockchain->hasBlock(blockId)) {
-    const auto existingRawBlock = m_kvBlockchain->getRawBlock(blockId);
-    if (rawBlock != existingRawBlock) {
-      LOG_ERROR(logger,
-                "found existing (and different) block ID[" << blockId << "] when receiving from state transfer");
-
-      // TODO consider assert?
-      m_kvBlockchain->deleteBlock(blockId);
-      throw std::runtime_error(
-          __PRETTY_FUNCTION__ +
-          std::string("found existing (and different) block when receiving state transfer, block ID: ") +
-          std::to_string(blockId));
-    }
-  } else {
-    m_kvBlockchain->addRawBlock(rawBlock, blockId, lastBlock);
-  }
-  return true;
+  return m_kvBlockchain->putBlock(blockId, blockData, blockSize, lastBlock);
 }
 
 std::future<bool> Replica::putBlockAsync(uint64_t blockId,
@@ -659,7 +631,7 @@ std::future<bool> Replica::putBlockAsync(uint64_t blockId,
   static uint64_t callCounter = 0;
   static constexpr size_t snapshotThresh = 1000;
 
-  auto future = blocksIOWorkersPool_.async(
+  auto future = blocks_io_workers_pool.async(
       [this](uint64_t blockId, const char *block, const uint32_t blockSize, bool lastBlock) {
         auto start = std::chrono::steady_clock::now();
         bool result = false;
@@ -701,7 +673,7 @@ uint64_t Replica::getLastReachableBlockNum() const {
   if (replicaConfig_.isReadOnly) {
     return m_bcDbAdapter->getLastReachableBlockId();
   }
-  return m_kvBlockchain->getLastReachableBlockId();
+  return m_kvBlockchain->getLastReachableBlockNum();
 }
 
 uint64_t Replica::getGenesisBlockNum() const { return getGenesisBlockId(); }
@@ -710,11 +682,7 @@ uint64_t Replica::getLastBlockNum() const {
   if (replicaConfig_.isReadOnly) {
     return m_bcDbAdapter->getLatestBlockId();
   }
-  const auto last = m_kvBlockchain->getLastStatetransferBlockId();
-  if (last) {
-    return *last;
-  }
-  return m_kvBlockchain->getLastReachableBlockId();
+  return m_kvBlockchain->getLastBlockNum();
 }
 
 size_t Replica::postProcessUntilBlockId(uint64_t max_block_id) {
@@ -722,34 +690,7 @@ size_t Replica::postProcessUntilBlockId(uint64_t max_block_id) {
     // read only replica do not post process
     return 0;
   }
-  const BlockId last_reachable_block = m_kvBlockchain->getLastReachableBlockId();
-  BlockId last_st_block_id = 0;
-  if (auto last_st_block_id_opt = m_kvBlockchain->getLastStatetransferBlockId()) {
-    last_st_block_id = last_st_block_id_opt.value();
-  }
-  if ((max_block_id == last_reachable_block) && (last_st_block_id == 0)) {
-    LOG_INFO(CAT_BLOCK_LOG,
-             "Consensus blockchain is fully linked, no proc-processing is required!"
-                 << KVLOG(max_block_id, last_reachable_block));
-    return 0;
-  }
-  if ((max_block_id < last_reachable_block) || (max_block_id > last_st_block_id)) {
-    auto msg = std::stringstream{};
-    msg << "Cannot post-process:" << KVLOG(max_block_id, last_reachable_block, last_st_block_id) << std::endl;
-    throw std::invalid_argument{msg.str()};
-  }
-
-  try {
-    return m_kvBlockchain->linkUntilBlockId(last_reachable_block + 1, max_block_id);
-  } catch (const std::exception &e) {
-    LOG_FATAL(
-        CAT_BLOCK_LOG,
-        "Aborting due to failure to link," << KVLOG(last_reachable_block, max_block_id) << ", reason: " << e.what());
-    std::terminate();
-  } catch (...) {
-    LOG_FATAL(CAT_BLOCK_LOG, "Aborting due to failure to link," << KVLOG(last_reachable_block, max_block_id));
-    std::terminate();
-  }
+  return m_kvBlockchain->postProcessUntilBlockId(max_block_id);
 }
 
 RawBlock Replica::getBlockInternal(BlockId blockId) const { return m_bcDbAdapter->getRawBlock(blockId); }
@@ -762,19 +703,7 @@ bool Replica::getBlock(uint64_t blockId, char *outBlock, uint32_t outBlockMaxSiz
   if (replicaConfig_.isReadOnly) {
     return getBlockFromObjectStore(blockId, outBlock, outBlockMaxSize, outBlockActualSize);
   }
-  const auto rawBlock = m_kvBlockchain->getRawBlock(blockId);
-  if (!rawBlock) {
-    throw NotFoundException{"Raw block not found: " + std::to_string(blockId)};
-  }
-  const auto &ser = categorization::RawBlock::serialize(*rawBlock);
-  if (ser.size() > outBlockMaxSize) {
-    LOG_ERROR(logger, KVLOG(ser.size(), outBlockMaxSize));
-    throw std::runtime_error("not enough space to copy block!");
-  }
-  *outBlockActualSize = ser.size();
-  LOG_DEBUG(logger, KVLOG(blockId, *outBlockActualSize));
-  std::memcpy(outBlock, ser.data(), *outBlockActualSize);
-  return true;
+  return m_kvBlockchain->getBlock(blockId, outBlock, outBlockMaxSize, outBlockActualSize);
 }
 
 std::future<bool> Replica::getBlockAsync(uint64_t blockId,
@@ -783,8 +712,7 @@ std::future<bool> Replica::getBlockAsync(uint64_t blockId,
                                          uint32_t *outBlockActualSize) {
   static uint64_t callCounter = 0;
   static constexpr size_t snapshotThresh = 1000;
-
-  auto future = blocksIOWorkersPool_.async(
+  auto future = blocks_io_workers_pool.async(
       [this](uint64_t blockId, char *outBlock, uint32_t outBlockMaxSize, uint32_t *outBlockActualSize) {
         bool result = false;
         auto start = std::chrono::steady_clock::now();
@@ -849,29 +777,16 @@ bool Replica::getPrevDigestFromBlock(BlockId blockId, StateTransferDigest *outPr
   if (replicaConfig_.isReadOnly) {
     return getPrevDigestFromObjectStoreBlock(blockId, outPrevBlockDigest);
   }
-  ConcordAssert(blockId > 0);
-  const auto parent_digest = m_kvBlockchain->parentDigest(blockId);
-
-  if (!parent_digest.has_value()) {
-    LOG_WARN(logger, "parent digest not found," << KVLOG(blockId));
-    return false;
-  }
-  static_assert(parent_digest->size() == DIGEST_SIZE);
-  static_assert(sizeof(StateTransferDigest) == DIGEST_SIZE);
-  std::memcpy(outPrevBlockDigest, parent_digest->data(), DIGEST_SIZE);
-  return true;
+  return m_kvBlockchain->getPrevDigestFromBlock(blockId, outPrevBlockDigest);
 }
 
 void Replica::getPrevDigestFromBlock(const char *blockData,
                                      const uint32_t blockSize,
                                      StateTransferDigest *outPrevBlockDigest) const {
-  ConcordAssertGT(blockSize, 0);
-  auto view = std::string_view{blockData, blockSize};
-  const auto rawBlock = categorization::RawBlock::deserialize(view);
-
-  static_assert(rawBlock.data.parent_digest.size() == DIGEST_SIZE);
-  static_assert(sizeof(StateTransferDigest) == DIGEST_SIZE);
-  std::memcpy(outPrevBlockDigest, rawBlock.data.parent_digest.data(), DIGEST_SIZE);
+  if (replicaConfig_.isReadOnly) {
+    return getPrevDigestFromObjectStoreBlock(blockData, blockSize, outPrevBlockDigest);
+  }
+  return m_kvBlockchain->getPrevDigestFromBlock(blockData, blockSize, outPrevBlockDigest);
 }
 
 bool Replica::getPrevDigestFromObjectStoreBlock(uint64_t blockId,
@@ -889,6 +804,18 @@ bool Replica::getPrevDigestFromObjectStoreBlock(uint64_t blockId,
     LOG_FATAL(logger, "Block not found for parent digest, ID: " << blockId << " " << e.what());
     throw;
   }
+}
+
+void Replica::getPrevDigestFromObjectStoreBlock(const char *blockData,
+                                                const uint32_t blockSize,
+                                                StateTransferDigest *outPrevBlockDigest) const {
+  ConcordAssertGT(blockSize, 0);
+  auto view = std::string_view{blockData, blockSize};
+  const auto rawBlock = categorization::RawBlock::deserialize(view);
+
+  static_assert(rawBlock.data.parent_digest.size() == DIGEST_SIZE);
+  static_assert(sizeof(StateTransferDigest) == DIGEST_SIZE);
+  std::memcpy(outPrevBlockDigest, rawBlock.data.parent_digest.data(), DIGEST_SIZE);
 }
 
 void Replica::registerStBasedReconfigurationHandler(

--- a/kvbc/src/blockchain_misc.cpp
+++ b/kvbc/src/blockchain_misc.cpp
@@ -1,0 +1,23 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "blockchain_misc.hpp"
+#include "storage/merkle_tree_key_manipulator.h"
+
+namespace concord::kvbc::bcutil {
+
+static const auto kPublicStateHashKey = concord::storage::v2MerkleTree::detail::serialize(
+    concord::storage::v2MerkleTree::detail::EBFTSubtype::PublicStateHashAtDbCheckpoint);
+
+std::string BlockChainUtils::publicStateHashKey() { return kPublicStateHashKey; }
+
+}  // end of namespace concord::kvbc::bcutil

--- a/kvbc/src/categorization/kv_blockchain.cpp
+++ b/kvbc/src/categorization/kv_blockchain.cpp
@@ -14,14 +14,12 @@
 #include "categorization/kv_blockchain.h"
 #include "bcstatetransfer/SimpleBCStateTransfer.hpp"
 #include "bftengine/ControlStateManager.hpp"
-#include "json_output.hpp"
 #include "diagnostics.h"
 #include "performance_handler.h"
 #include "kvbc_key_types.hpp"
 #include "categorization/db_categories.h"
 #include "endianness.hpp"
 #include "migrations/block_merkle_latest_ver_cf_migration.h"
-#include "storage/merkle_tree_key_manipulator.h"
 #include "categorization/details.h"
 #include "ReplicaConfig.hpp"
 #include "throughput.hpp"
@@ -33,16 +31,11 @@
 namespace concord::kvbc::categorization {
 
 using ::bftEngine::bcst::computeBlockDigest;
-using concordUtils::toPair;
 
 template <typename T>
 void nullopts(std::vector<std::optional<T>>& vec, std::size_t count) {
   vec.resize(count, std::nullopt);
 }
-
-const KeyValueBlockchain::Converter KeyValueBlockchain::kNoopConverter = [](std::string&& v) -> std::string {
-  return std::move(v);
-};
 
 KeyValueBlockchain::Recorders KeyValueBlockchain::histograms_;
 
@@ -188,7 +181,7 @@ BlockId KeyValueBlockchain::addBlock(Updates&& updates) {
   // Use new client batch and column families
   auto write_batch = native_client_->getBatch();
   addGenesisBlockKey(updates);
-  auto block_id = addBlock(std::move(updates.category_updates_), write_batch);
+  auto block_id = addBlock(updates.categoryUpdates(), write_batch);
   native_client_->write(std::move(write_batch));
   block_chain_.setAddedBlockId(block_id);
   return block_id;
@@ -402,11 +395,6 @@ void KeyValueBlockchain::trimBlocksFromSnapshot(BlockId block_id_at_checkpoint) 
   }
 }
 
-static const auto kPublicStateHashKey = concord::storage::v2MerkleTree::detail::serialize(
-    concord::storage::v2MerkleTree::detail::EBFTSubtype::PublicStateHashAtDbCheckpoint);
-
-std::string KeyValueBlockchain::publicStateHashKey() { return kPublicStateHashKey; }
-
 std::optional<PublicStateKeys> KeyValueBlockchain::getPublicStateKeys() const {
   const auto opt_val = getLatest(kConcordInternalCategoryId, keyTypes::state_public_key_set);
   if (!opt_val) {
@@ -489,7 +477,8 @@ void KeyValueBlockchain::computeAndPersistPublicStateHash(BlockId checkpoint_blo
     hasher.update(value.data(), value.size());
     hash = hasher.finish();
   });
-  native_client_->put(kPublicStateHashKey, detail::serialize(StateHash{checkpoint_block_id, hash}));
+  native_client_->put(concord::kvbc::bcutil::BlockChainUtils::publicStateHashKey(),
+                      detail::serialize(StateHash{checkpoint_block_id, hash}));
 }
 
 /////////////////////// Delete block ///////////////////////
@@ -981,24 +970,6 @@ void KeyValueBlockchain::writeSTLinkTransaction(const BlockId block_id, RawBlock
   native_client_->write(std::move(write_batch));
 
   block_chain_.setAddedBlockId(new_block_id);
-}
-
-std::string KeyValueBlockchain::getPruningStatus() {
-  std::ostringstream oss;
-  std::unordered_map<std::string, std::string> result;
-
-  result.insert(toPair("versionedNumOfDeletedKeys",
-                       aggregator_->GetCounter("kv_blockchain_deletes", "numOfVersionedKeysDeleted").Get()));
-  result.insert(toPair("immutableNumOfDeletedKeys",
-                       aggregator_->GetCounter("kv_blockchain_deletes", "numOfImmutableKeysDeleted").Get()));
-  result.insert(toPair("merkleNumOfDeletedKeys",
-                       aggregator_->GetCounter("kv_blockchain_deletes", "numOfMerkleKeysDeleted").Get()));
-  result.insert(toPair("getGenesisBlockId()", getGenesisBlockId()));
-  result.insert(toPair("getLastReachableBlockId()", getLastReachableBlockId()));
-  result.insert(toPair("isPruningInProgress", bftEngine::ControlStateManager::instance().getPruningProcessStatus()));
-
-  oss << concordUtils::kContainerToJson(result);
-  return oss.str();
 }
 
 }  // namespace concord::kvbc::categorization

--- a/kvbc/src/kvbc_adapter/app_state_adapter.cpp
+++ b/kvbc/src/kvbc_adapter/app_state_adapter.cpp
@@ -1,0 +1,133 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "kvbc_adapter/app_state_adapter.hpp"
+#include "assertUtils.hpp"
+
+namespace concord::kvbc::adapter {
+
+AppStateAdapter::AppStateAdapter(std::shared_ptr<concord::kvbc::categorization::KeyValueBlockchain> &kvbc)
+    : kvbc_{kvbc.get()}, logger_(logging::getLogger("skvbc.replica.appstateadapter")) {
+  ConcordAssertNE(kvbc_, nullptr);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// IAppState implementation
+bool AppStateAdapter::getBlock(uint64_t blockId,
+                               char *outBlock,
+                               uint32_t outBlockMaxSize,
+                               uint32_t *outBlockActualSize) const {
+  const auto rawBlock = kvbc_->getRawBlock(blockId);
+  if (!rawBlock) {
+    throw NotFoundException{"Raw block not found: " + std::to_string(blockId)};
+  }
+  const auto &ser = categorization::RawBlock::serialize(*rawBlock);
+  if (ser.size() > outBlockMaxSize) {
+    LOG_ERROR(logger_, KVLOG(ser.size(), outBlockMaxSize));
+    throw std::runtime_error("not enough space to copy block!");
+  }
+  *outBlockActualSize = ser.size();
+  std::memcpy(outBlock, ser.data(), *outBlockActualSize);
+  return true;
+}
+bool AppStateAdapter::getPrevDigestFromBlock(uint64_t blockId,
+                                             bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const {
+  ConcordAssert(blockId > 0);
+  const auto parent_digest = kvbc_->parentDigest(blockId);
+
+  if (!parent_digest.has_value()) {
+    LOG_WARN(logger_, "parent digest not found," << KVLOG(blockId));
+    return false;
+  }
+  static_assert(parent_digest->size() == DIGEST_SIZE);
+  static_assert(sizeof(bftEngine::bcst::StateTransferDigest) == DIGEST_SIZE);
+  std::memcpy(outPrevBlockDigest, parent_digest->data(), DIGEST_SIZE);
+  return true;
+}
+void AppStateAdapter::getPrevDigestFromBlock(const char *blockData,
+                                             const uint32_t blockSize,
+                                             bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const {
+  ConcordAssertGT(blockSize, 0);
+  auto view = std::string_view{blockData, blockSize};
+  const auto rawBlock = categorization::RawBlock::deserialize(view);
+
+  static_assert(rawBlock.data.parent_digest.size() == DIGEST_SIZE);
+  static_assert(sizeof(bftEngine::bcst::StateTransferDigest) == DIGEST_SIZE);
+  std::memcpy(outPrevBlockDigest, rawBlock.data.parent_digest.data(), DIGEST_SIZE);
+}
+bool AppStateAdapter::putBlock(const uint64_t blockId,
+                               const char *blockData,
+                               const uint32_t blockSize,
+                               bool lastBlock) {
+  auto view = std::string_view{blockData, blockSize};
+  const auto rawBlock = categorization::RawBlock::deserialize(view);
+  if (kvbc_->hasBlock(blockId)) {
+    const auto existingRawBlock = kvbc_->getRawBlock(blockId);
+    if (rawBlock != existingRawBlock) {
+      LOG_ERROR(logger_,
+                "found existing (and different) block ID[" << blockId << "] when receiving from state transfer");
+
+      // TODO consider assert?
+      kvbc_->deleteBlock(blockId);
+      throw std::runtime_error(
+          __PRETTY_FUNCTION__ +
+          std::string("found existing (and different) block when receiving state transfer, block ID: ") +
+          std::to_string(blockId));
+    }
+  } else {
+    kvbc_->addRawBlock(rawBlock, blockId, lastBlock);
+  }
+  return true;
+}
+// This method is used by state-transfer in order to find the latest block id in either the state-transfer chain or
+// the main blockchain
+uint64_t AppStateAdapter::getLastBlockNum() const {
+  const auto last = kvbc_->getLastStatetransferBlockId();
+  if (last) {
+    return *last;
+  }
+  return kvbc_->getLastReachableBlockId();
+}
+size_t AppStateAdapter::postProcessUntilBlockId(uint64_t max_block_id) {
+  const BlockId last_reachable_block = kvbc_->getLastReachableBlockId();
+  BlockId last_st_block_id = 0;
+  if (auto last_st_block_id_opt = kvbc_->getLastStatetransferBlockId()) {
+    last_st_block_id = last_st_block_id_opt.value();
+  }
+  if ((max_block_id == last_reachable_block) && (last_st_block_id == 0)) {
+    LOG_INFO(CAT_BLOCK_LOG,
+             "Consensus blockchain is fully linked, no proc-processing is required!"
+                 << KVLOG(max_block_id, last_reachable_block));
+    return 0;
+  }
+  if ((max_block_id < last_reachable_block) || (max_block_id > last_st_block_id)) {
+    auto msg = std::stringstream{};
+    msg << "Cannot post-process:" << KVLOG(max_block_id, last_reachable_block, last_st_block_id) << std::endl;
+    throw std::invalid_argument{msg.str()};
+  }
+
+  try {
+    return kvbc_->linkUntilBlockId(last_reachable_block + 1, max_block_id);
+  } catch (const std::exception &e) {
+    LOG_FATAL(
+        CAT_BLOCK_LOG,
+        "Aborting due to failure to link," << KVLOG(last_reachable_block, max_block_id) << ", reason: " << e.what());
+    std::terminate();
+  } catch (...) {
+    LOG_FATAL(CAT_BLOCK_LOG, "Aborting due to failure to link," << KVLOG(last_reachable_block, max_block_id));
+    std::terminate();
+  }
+}
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // End of namespace concord::kvbc::adapter

--- a/kvbc/src/kvbc_adapter/blocks_deleter_adapter.cpp
+++ b/kvbc/src/kvbc_adapter/blocks_deleter_adapter.cpp
@@ -1,0 +1,68 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "kvbc_adapter/blocks_deleter_adapter.hpp"
+#include "assertUtils.hpp"
+#include "IntervalMappingResourceManager.hpp"
+#include "ReplicaResources.h"
+
+using concord::performance::ISystemResourceEntity;
+
+namespace concord::kvbc::adapter {
+
+BlocksDeleterAdapter::BlocksDeleterAdapter(std::shared_ptr<concord::kvbc::categorization::KeyValueBlockchain> &kvbc,
+                                           const std::optional<aux::AdapterAuxTypes> &aux_types)
+    : kvbc_{kvbc.get()} {
+  if (aux_types.has_value()) {
+    replica_resources_.reset(&(aux_types->resource_entity_));
+  } else {
+    replica_resources_ = std::make_shared<ReplicaResourceEntity>();
+  }
+  ConcordAssertNE(kvbc_, nullptr);
+  ConcordAssertEQ(!replica_resources_, false);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// IBlocksDeleter implementation
+void BlocksDeleterAdapter::deleteGenesisBlock() {
+  const auto genesisBlock = kvbc_->getGenesisBlockId();
+  if (genesisBlock == 0) {
+    throw std::logic_error{"Cannot delete the genesis block from an empty blockchain"};
+  }
+  kvbc_->deleteBlock(genesisBlock);
+}
+BlockId BlocksDeleterAdapter::deleteBlocksUntil(BlockId until) {
+  const auto genesisBlock = kvbc_->getGenesisBlockId();
+  if (genesisBlock == 0) {
+    throw std::logic_error{"Cannot delete a block range from an empty blockchain"};
+  } else if (until <= genesisBlock) {
+    throw std::invalid_argument{"Invalid 'until' value passed to deleteBlocksUntil()"};
+  }
+
+  const auto lastReachableBlock = kvbc_->getLastReachableBlockId();
+  const auto lastDeletedBlock = std::min(lastReachableBlock, until - 1);
+  const auto start = std::chrono::steady_clock::now();
+  for (auto i = genesisBlock; i <= lastDeletedBlock; ++i) {
+    ISystemResourceEntity::scopedDurMeasurment mes(*replica_resources_,
+                                                   ISystemResourceEntity::type::pruning_avg_time_micro);
+    ConcordAssert(kvbc_->deleteBlock(i));
+  }
+  auto jobDuration =
+      std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start).count();
+  histograms_.delete_batch_blocks_duration->recordAtomic(jobDuration);
+  return lastDeletedBlock;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace concord::kvbc::adapter

--- a/kvbc/src/kvbc_adapter/kv_blockchain_adapter.cpp
+++ b/kvbc/src/kvbc_adapter/kv_blockchain_adapter.cpp
@@ -1,0 +1,24 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
+#include "assertUtils.hpp"
+
+namespace concord::kvbc::adapter {
+
+KeyValueBlockchain::KeyValueBlockchain(std::shared_ptr<concord::kvbc::categorization::KeyValueBlockchain> &kvbc)
+    : kvbc_{kvbc.get()} {
+  ConcordAssertNE(kvbc_, nullptr);
+}
+
+}  // namespace concord::kvbc::adapter

--- a/kvbc/src/kvbc_adapter/replica_adapter.cpp
+++ b/kvbc/src/kvbc_adapter/replica_adapter.cpp
@@ -1,0 +1,71 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "kvbc_adapter/replica_adapter.hpp"
+#include "kvbc_adapter/blocks_deleter_adapter.hpp"
+#include "kvbc_adapter/kv_blockchain_adapter.hpp"
+#include "kvbc_adapter/app_state_adapter.hpp"
+#include "kvbc_adapter/state_snapshot_adapter.hpp"
+
+namespace concord::kvbc::adapter {
+ReplicaBlockchain::~ReplicaBlockchain() {
+  deleter_ = nullptr;
+  reader_ = nullptr;
+  adder_ = nullptr;
+  app_state_ = nullptr;
+  state_snapshot_ = nullptr;
+  db_chkpt_ = nullptr;
+}
+
+void ReplicaBlockchain::switch_to_rawptr() {
+  deleter_ = up_deleter_.get();
+  reader_ = up_reader_.get();
+  adder_ = up_adder_.get();
+  app_state_ = up_app_state_.get();
+  state_snapshot_ = up_state_snapshot_.get();
+  db_chkpt_ = up_db_chkpt_.get();
+}
+
+ReplicaBlockchain::ReplicaBlockchain(
+    const std::shared_ptr<concord::storage::rocksdb::NativeClient> &native_client,
+    bool link_st_chain,
+    const std::optional<std::map<std::string, categorization::CATEGORY_TYPE>> &category_types,
+    const std::optional<aux::AdapterAuxTypes> &aux_types)
+    : logger_(logging::getLogger("skvbc.replica.adapter")) {
+  if (bftEngine::ReplicaConfig::instance().kvBlockchainVersion == BLOCKCHAIN_VERSION::CATEGORIZED_BLOCKCHAIN) {
+    kvbc_ = std::make_shared<concord::kvbc::categorization::KeyValueBlockchain>(
+        native_client, link_st_chain, category_types);
+    if (aux_types.has_value()) {
+      kvbc_->setAggregator(aux_types->aggregator_);
+    }
+    up_deleter_ = std::make_unique<concord::kvbc::adapter::BlocksDeleterAdapter>(kvbc_, aux_types);
+    up_reader_ = std::make_unique<concord::kvbc::adapter::KeyValueBlockchain>(kvbc_);
+    up_adder_ = std::make_unique<concord::kvbc::adapter::KeyValueBlockchain>(kvbc_);
+    up_app_state_ = std::make_unique<concord::kvbc::adapter::AppStateAdapter>(kvbc_);
+    up_state_snapshot_ = std::make_unique<concord::kvbc::adapter::statesnapshot::KVBCStateSnapshot>(kvbc_);
+    up_db_chkpt_ = std::make_unique<concord::kvbc::adapter::statesnapshot::KVBCStateSnapshot>(kvbc_);
+  } else if (bftEngine::ReplicaConfig::instance().kvBlockchainVersion == BLOCKCHAIN_VERSION::NATURAL_BLOCKCHAIN) {
+    // TODO: Not yet implemented
+    ConcordAssert(false);
+  }
+
+  switch_to_rawptr();
+  ConcordAssertNE(deleter_, nullptr);
+  ConcordAssertNE(reader_, nullptr);
+  ConcordAssertNE(adder_, nullptr);
+  ConcordAssertNE(app_state_, nullptr);
+  ConcordAssertNE(state_snapshot_, nullptr);
+  ConcordAssertNE(db_chkpt_, nullptr);
+}
+
+}  // namespace concord::kvbc::adapter

--- a/kvbc/src/kvbc_adapter/state_snapshot_adapter.cpp
+++ b/kvbc/src/kvbc_adapter/state_snapshot_adapter.cpp
@@ -1,0 +1,24 @@
+// Concord
+//
+// Copyright (c) 2022 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "assertUtils.hpp"
+#include "kvbc_adapter/state_snapshot_adapter.hpp"
+
+namespace concord::kvbc::adapter::statesnapshot {
+
+KVBCStateSnapshot::KVBCStateSnapshot(std::shared_ptr<concord::kvbc::categorization::KeyValueBlockchain>& kvbc)
+    : kvbc_(kvbc.get()) {
+  ConcordAssertNE(kvbc_, nullptr);
+}
+
+}  // End of namespace concord::kvbc::adapter::statesnapshot

--- a/kvbc/src/reconfiguration_kvbc_handler.cpp
+++ b/kvbc/src/reconfiguration_kvbc_handler.cpp
@@ -21,12 +21,12 @@
 #include "kvbc_app_filter/kvbc_key_types.h"
 #include "concord.cmf.hpp"
 #include "secrets_manager_plain.h"
-#include "communication/StateControl.hpp"
 #include "rocksdb/native_client.h"
-#include "categorization/categorized_reader.h"
+#include "kvbc_adapter/idempotent_reader.h"
 #include "categorization/db_categories.h"
 #include "categorization/details.h"
 #include "categorized_kvbc_msgs.cmf.hpp"
+#include "ReplicaResources.h"
 #include <chrono>
 #include <algorithm>
 #include <memory>
@@ -36,8 +36,7 @@ namespace concord::kvbc::reconfiguration {
 using bftEngine::impl::DbCheckpointManager;
 using bftEngine::impl::SigManager;
 using concord::kvbc::KvbAppFilter;
-using concord::kvbc::categorization::CategorizedReader;
-using concord::kvbc::categorization::KeyValueBlockchain;
+using concord::kvbc::adapter::IdempotentReader;
 using concord::messages::SnapshotResponseStatus;
 using concord::storage::rocksdb::NativeClient;
 
@@ -196,8 +195,8 @@ bool StateSnapshotReconfigurationHandler::handle(const concord::messages::StateS
         read_only,
         NativeClient::DefaultOptions{});
     const auto link_st_chain = false;
-    const auto kvbc = std::make_shared<const KeyValueBlockchain>(db, link_st_chain);
-    const auto reader = CategorizedReader{kvbc};
+    const auto idempotent_kvbc = std::make_shared<const adapter::ReplicaBlockchain>(db, link_st_chain);
+    const auto reader = IdempotentReader{idempotent_kvbc};
     const auto filter = KvbAppFilter{&reader, ""};
     if (bftEngine::ReplicaConfig::instance().enableEventGroups) {
       // TODO: We currently only support new participants and, therefore, the event group ID will always be the last
@@ -208,7 +207,7 @@ bool StateSnapshotReconfigurationHandler::handle(const concord::messages::StateS
       resp.data->blockchain_height = reader.getLastBlockId();
       resp.data->blockchain_height_type = messages::BlockchainHeightType::BlockId;
     }
-    const auto public_state = kvbc->getPublicStateKeys();
+    const auto public_state = idempotent_kvbc->getPublicStateKeys();
     if (!public_state) {
       resp.data->key_value_count_estimate = 0;
     } else {
@@ -295,7 +294,7 @@ bool StateSnapshotReconfigurationHandler::handle(const concord::messages::Signed
       const auto read_only = true;
       try {
         auto db = NativeClient::newClient(snapshot_path, read_only, NativeClient::DefaultOptions{});
-        const auto ser_hash = db->get(KeyValueBlockchain::publicStateHashKey());
+        const auto ser_hash = db->get(concord::kvbc::bcutil::BlockChainUtils::publicStateHashKey());
         if (!ser_hash) {
           LOG_ERROR(getLogger(),
                     "SignedPublicStateHashRequest: missing public state hash for snapshot ID = "
@@ -361,7 +360,7 @@ bool StateSnapshotReconfigurationHandler::handle(const concord::messages::StateS
       try {
         auto db = NativeClient::newClient(snapshot_path, read_only, NativeClient::DefaultOptions{});
         const auto link_st_chain = false;
-        const auto kvbc = KeyValueBlockchain{db, link_st_chain};
+        const auto kvbc = adapter::ReplicaBlockchain{db, link_st_chain};
         const auto public_state = kvbc.getPublicStateKeys();
         auto values = std::vector<std::optional<categorization::Value>>{};
         kvbc.multiGetLatest(categorization::kExecutionProvableCategory, req.keys, values);
@@ -1234,9 +1233,9 @@ bool InternalPostKvReconfigurationHandler::handle(const concord::messages::Clien
   if (!bftEngine::ReplicaConfig::instance().saveClinetKeyFile) return true;
   // Now that keys have exchanged, lets persist the new key in the file system
   uint32_t group_id = 0;
-  for (const auto& [id, cgr] : bftEngine::ReplicaConfig::instance().clientGroups) {
+  for (const auto& [gid, cgr] : bftEngine::ReplicaConfig::instance().clientGroups) {
     if (std::find(cgr.begin(), cgr.end(), sender_id) != cgr.end()) {
-      group_id = id;
+      group_id = gid;
       break;
     }
   }

--- a/kvbc/src/replica_state_sync_imp.cpp
+++ b/kvbc/src/replica_state_sync_imp.cpp
@@ -10,7 +10,6 @@
 // notices and license terms. Your use of these subcomponents is subject to the
 // terms and conditions of the subcomponent's license, as noted in the LICENSE
 // file.
-//
 
 #include "assertUtils.hpp"
 #include "replica_state_sync_imp.hpp"
@@ -28,7 +27,7 @@ namespace concord::kvbc {
 ReplicaStateSyncImp::ReplicaStateSyncImp(IBlockMetadata* blockMetadata) : blockMetadata_(blockMetadata) {}
 
 uint64_t ReplicaStateSyncImp::execute(logging::Logger& logger,
-                                      categorization::KeyValueBlockchain& blockchain,
+                                      adapter::ReplicaBlockchain& blockchain,
                                       const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                                       uint64_t lastExecutedSeqNum,
                                       uint32_t maxNumOfBlocksToDelete) {
@@ -58,7 +57,7 @@ uint64_t ReplicaStateSyncImp::execute(logging::Logger& logger,
 }
 
 uint64_t ReplicaStateSyncImp::executeBasedOnBftSeqNum(logging::Logger& logger,
-                                                      categorization::KeyValueBlockchain& blockchain,
+                                                      adapter::ReplicaBlockchain& blockchain,
                                                       uint64_t lastExecutedSeqNum,
                                                       uint32_t maxNumOfBlocksToDelete) {
   if (!lastExecutedSeqNum) {
@@ -67,7 +66,7 @@ uint64_t ReplicaStateSyncImp::executeBasedOnBftSeqNum(logging::Logger& logger,
   }
   uint64_t removedBlocksNum = 0;
   const auto genesisBlockId = blockchain.getGenesisBlockId();
-  BlockId lastReachableBlockId = blockchain.getLastReachableBlockId();
+  BlockId lastReachableBlockId = blockchain.getLastBlockId();
   uint64_t lastBlockSeqNum = 0;
   while (lastReachableBlockId && genesisBlockId <= lastReachableBlockId) {
     // Get execution sequence number stored in the current last block.
@@ -88,17 +87,17 @@ uint64_t ReplicaStateSyncImp::executeBasedOnBftSeqNum(logging::Logger& logger,
       throw std::runtime_error(__PRETTY_FUNCTION__ + error);
     }
     blockchain.deleteLastReachableBlock();
-    lastReachableBlockId = blockchain.getLastReachableBlockId();
+    lastReachableBlockId = blockchain.getLastBlockId();
     ++removedBlocksNum;
   }
   LOG_INFO(logger,
            "Inconsistent blockchain block deleted "
-               << KVLOG(removedBlocksNum, lastExecutedSeqNum, lastBlockSeqNum, blockchain.getLastReachableBlockId()));
+               << KVLOG(removedBlocksNum, lastExecutedSeqNum, lastBlockSeqNum, blockchain.getLastBlockId()));
   return removedBlocksNum;
 }
 
 uint64_t ReplicaStateSyncImp::executeBasedOnBlockId(logging::Logger& logger,
-                                                    categorization::KeyValueBlockchain& blockchain,
+                                                    adapter::ReplicaBlockchain& blockchain,
                                                     const std::shared_ptr<bftEngine::impl::PersistentStorage>& metadata,
                                                     uint32_t maxNumOfBlocksToDelete) {
   if (0 == maxNumOfBlocksToDelete) {
@@ -110,7 +109,7 @@ uint64_t ReplicaStateSyncImp::executeBasedOnBlockId(logging::Logger& logger,
   const auto lastMtdBlockId = getLastBlockIdFromMetadata(metadata);
   ConcordAssert(lastMtdBlockId.has_value());
   const auto genesisBlockId = blockchain.getGenesisBlockId();
-  auto lastReachableKvbcBlockId = blockchain.getLastReachableBlockId();
+  auto lastReachableKvbcBlockId = blockchain.getLastBlockId();
   auto deletedBlocks = uint64_t{0};
   // Even though the KVBC implementation at the time of writing cannot delete the only block left (the genesis block in
   // the loop below can be the only one left), we still write the code here so that it attempts to delete, even though
@@ -118,7 +117,7 @@ uint64_t ReplicaStateSyncImp::executeBasedOnBlockId(logging::Logger& logger,
   // stopping the system and await manual intervention as the next startup would lead to the same situation.
   while (lastReachableKvbcBlockId > lastMtdBlockId && genesisBlockId <= lastReachableKvbcBlockId) {
     blockchain.deleteLastReachableBlock();
-    lastReachableKvbcBlockId = blockchain.getLastReachableBlockId();
+    lastReachableKvbcBlockId = blockchain.getLastBlockId();
     ++deletedBlocks;
 
     if (deletedBlocks == maxNumOfBlocksToDelete) {

--- a/kvbc/src/resources-manager/IntervalMappingResourceManager.cpp
+++ b/kvbc/src/resources-manager/IntervalMappingResourceManager.cpp
@@ -16,7 +16,7 @@ using namespace concord::performance;
 
 // IntervalMappingResourceManager::IntervalMappingResourceManager(ISystemResourceEntity &replicaResources,
 //                                  std::vector<std::pair<uint64_t, uint64_t>> &&intervalMapping)
-//       : replicaResources_(replicaResources), intervalMapping_(std::move(intervalMapping)) {
+//       : replica_resources_(replicaResources), intervalMapping_(std::move(intervalMapping)) {
 //         std::ostringstream intervals;
 //         for(const auto& p:intervalMapping_){
 //           intervals << "{" << p.first << "," << p.second << "},";

--- a/kvbc/test/categorization/blocks_test.cpp
+++ b/kvbc/test/categorization/blocks_test.cpp
@@ -20,7 +20,6 @@
 #include "categorization/updates.h"
 #include "categorization/kv_blockchain.h"
 #include "categorization/db_categories.h"
-#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/kvbc/test/categorization/kv_blockchain_test.cpp
+++ b/kvbc/test/categorization/kv_blockchain_test.cpp
@@ -74,7 +74,7 @@ class categorized_kvbc : public Test {
   // h3 = hash(h2 || hash("c") || "vc") = c6314bdd9c82183d2e4e5cb8869826e1a3ace6a86a7b62ebe5ac77b732d3c792
   // h4 = hash(h3 || hash("d") || "vd") = fd4c5ea03da18deaf10365fdf001c216055aaaa796b0a98e4db7c756a426ae81
   void assertPublicStateHash() {
-    const auto state_hash_val = db->get(KeyValueBlockchain::publicStateHashKey());
+    const auto state_hash_val = db->get(concord::kvbc::bcutil::BlockChainUtils::publicStateHashKey());
     ASSERT_TRUE(state_hash_val.has_value());
     auto state_hash = StateHash{};
     detail::deserialize(*state_hash_val, state_hash);
@@ -2456,7 +2456,7 @@ TEST_F(categorized_kvbc, compute_and_persist_hash_with_no_public_state) {
                                            {kConcordInternalCategoryId, CATEGORY_TYPE::versioned_kv}}};
   ASSERT_EQ(kvbc.addBlock(Updates{}), 1);
   kvbc.computeAndPersistPublicStateHash(1);
-  const auto state_hash_val = db->get(KeyValueBlockchain::publicStateHashKey());
+  const auto state_hash_val = db->get(concord::kvbc::bcutil::BlockChainUtils::publicStateHashKey());
   ASSERT_TRUE(state_hash_val.has_value());
   auto state_hash = StateHash{};
   detail::deserialize(*state_hash_val, state_hash);

--- a/kvbc/test/pruning_test.cpp
+++ b/kvbc/test/pruning_test.cpp
@@ -12,7 +12,6 @@
 
 #include "gtest/gtest.h"
 #include <bftengine/ControlStateManager.hpp>
-#include <bftengine/ControlStateManager.hpp>
 #include "NullStateTransfer.hpp"
 #include "categorization/kv_blockchain.h"
 #include "categorization/updates.h"
@@ -37,6 +36,7 @@ using concord::kvbc::BlockId;
 using namespace concord::kvbc;
 using namespace concord::kvbc::categorization;
 using namespace concord::kvbc::pruning;
+
 namespace {
 const NodeIdType replica_0 = 0;
 const NodeIdType replica_1 = 1;
@@ -441,10 +441,12 @@ class TestStorage : public IReader, public IBlockAdder, public IBlocksDeleter {
     return lastDeletedBlock;
   }
 
+  void deleteLastReachableBlock() override { return bc_.deleteLastReachableBlock(); }
+
   void setGenesisBlockId(BlockId bid) { mockGenesisBlockId = bid; }
 
  private:
-  KeyValueBlockchain bc_;
+  concord::kvbc::categorization::KeyValueBlockchain bc_;
   std::optional<BlockId> mockGenesisBlockId = {};
 };
 

--- a/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
+++ b/kvbc/test/sparse_merkle_storage/kv_blockchain_db_editor_test.cpp
@@ -30,7 +30,7 @@ class DbEditorTests : public DbEditorTestsBase {
  public:
   void CreateBlockchain(std::size_t db_id, BlockId blocks, std::optional<BlockId> mismatch_at = std::nullopt) override {
     auto db = TestRocksDb::create(db_id);
-    auto adapter = KeyValueBlockchain{
+    auto adapter = concord::kvbc::categorization::KeyValueBlockchain{
         concord::storage::rocksdb::NativeClient::fromIDBClient(db),
         true,
         std::map<std::string, CATEGORY_TYPE>{
@@ -97,7 +97,7 @@ class DbEditorTests : public DbEditorTestsBase {
 
   void DeleteBlocksUntil(std::size_t db_id, BlockId until_block_id) override {
     auto db = TestRocksDb::createNative(db_id);
-    auto adapter = KeyValueBlockchain{db, true};
+    auto adapter = concord::kvbc::categorization::KeyValueBlockchain{db, true};
 
     for (auto i = 1ull; i < until_block_id; ++i) {
       adapter.deleteBlock(i);

--- a/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
+++ b/kvbc/tools/db_editor/include/kv_blockchain_db_editor.hpp
@@ -678,7 +678,6 @@ struct CompareTo {
       throw std::invalid_argument{"Missing PATH-TO-OTHER-DB argument"};
     }
 
-    const auto read_only = true;
     const auto other_adapter = getAdapter(args.values.front(), read_only);
 
     const auto main_genesis = main_adapter.getGenesisBlockId();

--- a/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
+++ b/tests/simpleKVBC/TesterReplica/internalCommandsHandler.hpp
@@ -26,7 +26,7 @@
 #include "skvbc_messages.cmf.hpp"
 #include "SharedTypes.hpp"
 #include "categorization/db_categories.h"
-#include "categorization/kv_blockchain.h"
+#include "kvbc_adapter/replica_adapter.hpp"
 
 static const std::string VERSIONED_KV_CAT_ID{concord::kvbc::categorization::kExecutionPrivateCategory};
 static const std::string BLOCK_MERKLE_CAT_ID{concord::kvbc::categorization::kExecutionProvableCategory};
@@ -38,7 +38,7 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
                           concord::kvbc::IBlockMetadata *blockMetadata,
                           logging::Logger &logger,
                           bool addAllKeysAsPublic = false,
-                          concord::kvbc::categorization::KeyValueBlockchain *kvbc = nullptr)
+                          concord::kvbc::adapter::ReplicaBlockchain *kvbc = nullptr)
       : m_storage(storage),
         m_blockAdder(blocksAdder),
         m_blockMetadata(blockMetadata),
@@ -136,5 +136,5 @@ class InternalCommandsHandler : public concord::kvbc::ICommandsHandler {
   size_t m_getLastBlockCounter = 0;
   std::shared_ptr<concord::performance::PerformanceManager> perfManager_;
   bool m_addAllKeysAsPublic{false};  // Add all key-values in the block merkle category as public ones.
-  concord::kvbc::categorization::KeyValueBlockchain *m_kvbc{nullptr};
+  concord::kvbc::adapter::ReplicaBlockchain *m_kvbc{nullptr};
 };

--- a/tests/simpleKVBC/TesterReplica/main.cpp
+++ b/tests/simpleKVBC/TesterReplica/main.cpp
@@ -72,15 +72,15 @@ class STAddRemoveHandlerTest : public concord::client::reconfiguration::IStateHa
   }
 };
 
-void cronSetup(TestSetup& setup, const Replica& replica) {
+void cronSetup(TestSetup& setup, const Replica& main_replica) {
   if (!setup.GetCronEntryNumberOfExecutes()) {
     return;
   }
   const auto numberOfExecutes = *setup.GetCronEntryNumberOfExecutes();
 
   using namespace concord::cron;
-  const auto cronTableRegistry = replica.cronTableRegistry();
-  const auto ticksGenerator = replica.ticksGenerator();
+  const auto cronTableRegistry = main_replica.cronTableRegistry();
+  const auto ticksGenerator = main_replica.ticksGenerator();
 
   auto& cronTable = cronTableRegistry->operator[](TestSetup::kCronTableComponentId);
 
@@ -145,7 +145,7 @@ void run_replica(int argc, char** argv) {
                                                 setup->AddAllKeysAsPublic(),
                                                 replica->kvBlockchain() ? &replica->kvBlockchain().value() : nullptr);
   replica->set_command_handler(cmdHandler);
-  replica->setStateSnapshotValueConverter(categorization::KeyValueBlockchain::kNoopConverter);
+  replica->setStateSnapshotValueConverter([](std::string&& v) -> std::string { return std::move(v); });
   replica->start();
 
   auto& replicaConfig = setup->GetReplicaConfig();

--- a/thin-replica-server/include/thin-replica-server/replica_state_snapshot_service_impl.hpp
+++ b/thin-replica-server/include/thin-replica-server/replica_state_snapshot_service_impl.hpp
@@ -16,11 +16,12 @@
 #include "replica_state_snapshot.grpc.pb.h"
 
 #include "bftengine/DbCheckpointManager.hpp"
-#include "categorization/kv_blockchain.h"
 #include "kvbc_app_filter/value_from_kvbc_proto.h"
+#include "blockchain_misc.hpp"
 
 #include <optional>
 #include <string>
+#include <memory>
 
 namespace concord::thin_replica {
 
@@ -38,9 +39,7 @@ class ReplicaStateSnapshotServiceImpl
       ::grpc::ServerWriter< ::vmware::concord::replicastatesnapshot::StreamSnapshotResponse>* writer) override;
 
   // Allows users to convert state values to any format that is appropriate.
-  void setStateValueConverter(const kvbc::categorization::KeyValueBlockchain::Converter& c) {
-    state_value_converter_ = c;
-  }
+  void setStateValueConverter(const concord::kvbc::Converter& c) { state_value_converter_ = c; }
 
   // Following methods are used for testing only. Please do not use in production.
   void overrideCheckpointPathForTest(const std::string& path) { overriden_path_for_test_ = path; }
@@ -55,7 +54,7 @@ class ReplicaStateSnapshotServiceImpl
   bool throw_exception_for_test_{false};
   // Allows users to convert state values to any format that is appropriate.
   // The default converter extracts the value from the ValueWithTrids protobuf type.
-  kvbc::categorization::KeyValueBlockchain::Converter state_value_converter_{kvbc::valueFromKvbcProto};
+  concord::kvbc::Converter state_value_converter_{kvbc::valueFromKvbcProto};
 };
 
 }  // namespace concord::thin_replica


### PR DESCRIPTION
In this PR a kvbc_adapter layer is created which contains various
concrete implementation of the KVBC interfaces. Any component outside
KVBC will access all the features of KVBC using these interfaces. We
have various adaptations or comcrete implementations of these interfaces
as below:
1) Replica Adapter: This adapter is the main entry point which will now
encapsulate all the interfaces of kvbc
2) KV Blockchain Adapter : This adapter implement the IReader and IAdder
interfaces
3) Blocks Deleter Adapter : This adapter implements the IBlocksDeleter
Interface.
4) App State Adapter : This adapter implements the IAppState interface.
5) State Snapshot Adapter : This adapter implements the interfaces
required for Replica State Snapshot.

Replica is another concrete implementation available at a higher level.
All the code which chooses the DB interface between readonly replica and
replica adapter is kept in Replica class.

In future all the boiler plate code which will be needed for all the
different versions of blockchain, will be in the replica_adapter. And
the code which is required only for the corresponding blockchain version
will be kept in the corresponding blockchain specific adapter.