### PR TITLE
Implementation of the state transfer interface

### DIFF
--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(kvbc  src/ClientImp.cpp
     src/kvbc_adapter/categorization/blocks_deleter_adapter.cpp
 
     src/kvbc_adapter/v4blockchain/blocks_deleter_adapter.cpp
+    src/kvbc_adapter/v4blockchain/app_state_adapter.cpp
 
     src/kvbc_adapter/replica_adapter.cpp
 )

--- a/kvbc/include/kvbc_adapter/v4blockchain/app_state_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/v4blockchain/app_state_adapter.hpp
@@ -1,0 +1,82 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#pragma once
+
+#include <string>
+
+#include "bcstatetransfer/SimpleBCStateTransfer.hpp"
+#include "v4blockchain/v4_blockchain.h"
+#include "kvbc_adapter/replica_adapter_auxilliary_types.hpp"
+
+using concord::storage::rocksdb::NativeClient;
+
+namespace concord::kvbc::adapter::v4blockchain {
+
+class AppStateAdapter : public bftEngine::bcst::IAppState {
+ public:
+  virtual ~AppStateAdapter() { kvbc_ = nullptr; }
+  explicit AppStateAdapter(std::shared_ptr<concord::kvbc::v4blockchain::KeyValueBlockchain> &kvbc,
+                           const std::optional<aux::AdapterAuxTypes> &aux_types = std::nullopt)
+      : kvbc_{kvbc.get()} {}
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  virtual bool hasBlock(uint64_t id) const override { return kvbc_->hasBlock(id); }
+  virtual bool getBlock(uint64_t blockId,
+                        char *outBlock,
+                        uint32_t outBlockMaxSize,
+                        uint32_t *outBlockActualSize) const override;
+
+  virtual std::future<bool> getBlockAsync(uint64_t blockId,
+                                          char *outBlock,
+                                          uint32_t outBlockMaxSize,
+                                          uint32_t *outBlockActualSize) override {
+    // This function is implemented in the replica.cpp
+    ConcordAssert(false);
+    return std::async([]() { return false; });
+  }
+  virtual bool getPrevDigestFromBlock(uint64_t blockId,
+                                      bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const override;
+
+  // Extracts a digest out of in-memory block (raw block).
+  virtual void getPrevDigestFromBlock(const char *blockData,
+                                      const uint32_t blockSize,
+                                      bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const override;
+
+  virtual bool putBlock(const uint64_t blockId,
+                        const char *blockData,
+                        const uint32_t blockSize,
+                        bool lastBlock) override;
+
+  virtual std::future<bool> putBlockAsync(uint64_t blockId,
+                                          const char *block,
+                                          const uint32_t blockSize,
+                                          bool lastBlock) override {
+    // This function is implemented in replica.cpp
+    ConcordAssert(false);
+    return std::async([]() { return false; });
+  }
+
+  virtual uint64_t getLastReachableBlockNum() const override { return kvbc_->getLastReachableBlockId(); }
+
+  virtual uint64_t getGenesisBlockNum() const override { return kvbc_->getGenesisBlockId(); }
+
+  virtual uint64_t getLastBlockNum() const override;
+
+  virtual size_t postProcessUntilBlockId(uint64_t max_block_id) override;
+
+ private:
+  concord::kvbc::v4blockchain::KeyValueBlockchain *kvbc_{nullptr};
+};
+
+}  // namespace concord::kvbc::adapter::v4blockchain

--- a/kvbc/include/v4blockchain/detail/blockchain.h
+++ b/kvbc/include/v4blockchain/detail/blockchain.h
@@ -51,6 +51,8 @@ class Blockchain {
   BlockId deleteBlocksUntil(BlockId until);
   void deleteGenesisBlock();
   void deleteLastReachableBlock(storage::rocksdb::NativeWriteBatch&);
+  ///////////////////State Transfer/////////////////////////////////
+  bool hasBlock(BlockId) const;
   ///////////////////////////////////////////////////////////////
   // Loads from storage the last and first block ids respectivly.
   std::optional<BlockId> loadLastReachableBlockId();
@@ -64,6 +66,7 @@ class Blockchain {
   std::optional<std::string> getBlockData(concord::kvbc::BlockId id) const;
   std::optional<categorization::Updates> getBlockUpdates(BlockId id) const;
 
+  concord::util::digest::BlockDigest getBlockParentDigest(concord::kvbc::BlockId id) const;
   concord::util::digest::BlockDigest calculateBlockDigest(concord::kvbc::BlockId id) const;
 
   // Generates a key (big endian string representation) from the block id.

--- a/kvbc/src/kvbc_adapter/v4blockchain/app_state_adapter.cpp
+++ b/kvbc/src/kvbc_adapter/v4blockchain/app_state_adapter.cpp
@@ -1,0 +1,113 @@
+// Concord
+//
+// Copyright (c) 2022-2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "db_adapter_interface.h"
+#include "kvbc_adapter/v4blockchain/app_state_adapter.hpp"
+#include "v4blockchain/detail/blocks.h"
+#include "v4blockchain/detail/detail.h"
+
+using namespace concord::kvbc;
+
+namespace concord::kvbc::adapter::v4blockchain {
+
+bool AppStateAdapter::getBlock(uint64_t blockId,
+                               char *outBlock,
+                               uint32_t outBlockMaxSize,
+                               uint32_t *outBlockActualSize) const {
+  auto blockData = kvbc_->getBlockData(blockId);
+  if (!blockData) {
+    throw kvbc::NotFoundException{"block not found: " + std::to_string(blockId)};
+  }
+  if (blockData->size() > outBlockMaxSize) {
+    LOG_ERROR(V4_BLOCK_LOG, KVLOG(blockData->size(), outBlockMaxSize));
+    throw std::runtime_error("not enough space to copy block!");
+  }
+  *outBlockActualSize = blockData->size();
+  std::memcpy(outBlock, blockData->c_str(), *outBlockActualSize);
+  return true;
+}
+
+bool AppStateAdapter::getPrevDigestFromBlock(uint64_t blockId,
+                                             bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const {
+  ConcordAssert(blockId > 0);
+  const auto parent_digest = kvbc_->parentDigest(blockId);
+  static_assert(parent_digest.size() == DIGEST_SIZE);
+  static_assert(sizeof(bftEngine::bcst::StateTransferDigest) == DIGEST_SIZE);
+  std::memcpy(outPrevBlockDigest, parent_digest.data(), DIGEST_SIZE);
+  return true;
+}
+
+void AppStateAdapter::getPrevDigestFromBlock(const char *blockData,
+                                             const uint32_t blockSize,
+                                             bftEngine::bcst::StateTransferDigest *outPrevBlockDigest) const {
+  ConcordAssertGE(blockSize, ::v4blockchain::detail::Block::HEADER_SIZE);
+  const auto &digest = *reinterpret_cast<const concord::util::digest::BlockDigest *>(
+      blockData + sizeof(::v4blockchain::detail::version_type));
+
+  std::memcpy(outPrevBlockDigest, digest.data(), DIGEST_SIZE);
+}
+
+bool AppStateAdapter::putBlock(const uint64_t blockId,
+                               const char *blockData,
+                               const uint32_t blockSize,
+                               bool lastBlock) {
+  const auto lastReachable = kvbc_->getLastReachableBlockId();
+  if (blockId <= lastReachable) {
+    const auto msg = "Cannot add an existing block ID " + std::to_string(blockId);
+    throw std::invalid_argument{msg};
+  }
+
+  kvbc_->addBlockToSTChain(blockId, blockData, blockSize, lastBlock);
+  return true;
+}
+
+uint64_t AppStateAdapter::getLastBlockNum() const {
+  const auto last = kvbc_->getLastStatetransferBlockId();
+  if (last) {
+    return *last;
+  }
+  return kvbc_->getLastReachableBlockId();
+}
+
+size_t AppStateAdapter::postProcessUntilBlockId(uint64_t max_block_id) {
+  const BlockId last_reachable_block = kvbc_->getLastReachableBlockId();
+  BlockId last_st_block_id = 0;
+  if (auto last_st_block_id_opt = kvbc_->getLastStatetransferBlockId()) {
+    last_st_block_id = last_st_block_id_opt.value();
+  }
+  if ((max_block_id == last_reachable_block) && (last_st_block_id == 0)) {
+    LOG_INFO(CAT_BLOCK_LOG,
+             "Consensus blockchain is fully linked, no proc-processing is required!"
+                 << KVLOG(max_block_id, last_reachable_block));
+    return 0;
+  }
+  if ((max_block_id < last_reachable_block) || (max_block_id > last_st_block_id)) {
+    auto msg = std::stringstream{};
+    msg << "Cannot post-process:" << KVLOG(max_block_id, last_reachable_block, last_st_block_id) << std::endl;
+    throw std::invalid_argument{msg.str()};
+  }
+
+  try {
+    return kvbc_->linkUntilBlockId(max_block_id);
+  } catch (const std::exception &e) {
+    LOG_FATAL(
+        CAT_BLOCK_LOG,
+        "Aborting due to failure to link," << KVLOG(last_reachable_block, max_block_id) << ", reason: " << e.what());
+    std::terminate();
+  } catch (...) {
+    LOG_FATAL(CAT_BLOCK_LOG, "Aborting due to failure to link," << KVLOG(last_reachable_block, max_block_id));
+    std::terminate();
+  }
+}
+
+}  // namespace concord::kvbc::adapter::v4blockchain

--- a/kvbc/src/v4blockchain/detail/blockchain.cpp
+++ b/kvbc/src/v4blockchain/detail/blockchain.cpp
@@ -115,6 +115,12 @@ concord::util::digest::BlockDigest Blockchain::calculateBlockDigest(concord::kvb
   return v4blockchain::detail::Block::calculateDigest(id, block_str->c_str(), block_str->size());
 }
 
+concord::util::digest::BlockDigest Blockchain::getBlockParentDigest(concord::kvbc::BlockId id) const {
+  auto block_str = getBlockData(id);
+  ConcordAssert(block_str.has_value());
+  return v4blockchain::detail::Block{*block_str}.parentDigest();
+}
+
 std::optional<std::string> Blockchain::getBlockData(concord::kvbc::BlockId id) const {
   auto blockKey = generateKey(id);
   return native_client_->get(v4blockchain::detail::BLOCKS_CF, blockKey);
@@ -150,6 +156,11 @@ std::optional<BlockId> Blockchain::loadGenesisBlockId() {
 void Blockchain::setBlockId(BlockId id) {
   setLastReachable(id);
   if (genesis_block_id_ == INVALID_BLOCK_ID) genesis_block_id_ = id;
+}
+
+bool Blockchain::hasBlock(BlockId block_id) const {
+  if (block_id > last_reachable_block_id_) return false;
+  return native_client_->getSlice(v4blockchain::detail::BLOCKS_CF, generateKey(block_id)).has_value();
 }
 
 }  // namespace concord::kvbc::v4blockchain::detail

--- a/kvbc/src/v4blockchain/detail/st_chain.cpp
+++ b/kvbc/src/v4blockchain/detail/st_chain.cpp
@@ -13,6 +13,7 @@
 
 #include "v4blockchain/detail/st_chain.h"
 #include "v4blockchain/detail/column_families.h"
+#include "v4blockchain/detail/blockchain.h"
 #include "Logger.hpp"
 
 namespace concord::kvbc::v4blockchain::detail {
@@ -23,6 +24,76 @@ StChain::StChain(const std::shared_ptr<concord::storage::rocksdb::NativeClient>&
     LOG_INFO(V4_BLOCK_LOG,
              "Created [" << v4blockchain::detail::ST_CHAIN_CF << "] column family for the state transfer blockchain");
   }
+  loadLastBlockId();
+  if (last_block_id_ > 0) {
+    LOG_INFO(CAT_BLOCK_LOG, "State transfer last block id: " << last_block_id_);
+  }
+}
+
+/////////// BLOCKS/////////////////////////
+bool StChain::hasBlock(BlockId block_id) const {
+  if (last_block_id_ < block_id) return false;
+  return native_client_
+      ->getSlice(v4blockchain::detail::ST_CHAIN_CF, v4blockchain::detail::Blockchain::generateKey(block_id))
+      .has_value();
+}
+
+void StChain::addBlock(const BlockId id, const char* block, const uint32_t blockSize) {
+  auto write_batch = native_client_->getBatch();
+  write_batch.put(v4blockchain::detail::ST_CHAIN_CF,
+                  v4blockchain::detail::Blockchain::generateKey(id),
+                  ::rocksdb::Slice(block, blockSize));
+  native_client_->write(std::move(write_batch));
+  updateLastIdIfBigger(id);
+}
+
+void StChain::deleteBlock(const BlockId id, storage::rocksdb::NativeWriteBatch& wb) {
+  wb.del(v4blockchain::detail::ST_CHAIN_CF, v4blockchain::detail::Blockchain::generateKey(id));
+}
+/////////////// ST LAST BLOCK ID ////////////
+void StChain::loadLastBlockId() {
+  auto itr = native_client_->getIterator(v4blockchain::detail::ST_CHAIN_CF);
+  auto max_db_key = v4blockchain::detail::Blockchain::generateKey(v4blockchain::detail::Blockchain::MAX_BLOCK_ID);
+  itr.seekAtMost(max_db_key);
+  if (!itr) {
+    last_block_id_ = 0;
+    return;
+  }
+  last_block_id_ = concordUtils::fromBigEndianBuffer<BlockId>(itr.keyView().data());
+}
+
+void StChain::updateLastIdAfterDeletion(const BlockId id) {
+  if (last_block_id_ == 0 || last_block_id_ != id) {
+    return;
+  }
+  last_block_id_ = 0;
+  loadLastBlockId();
+  return;
+}
+
+void StChain::updateLastIdIfBigger(const BlockId id) {
+  if (last_block_id_ >= id) {
+    return;
+  }
+  last_block_id_ = id;
+}
+
+std::optional<v4blockchain::detail::Block> StChain::getBlock(kvbc::BlockId id) const {
+  auto key = v4blockchain::detail::Blockchain::generateKey(id);
+  auto opt_block_str = native_client_->get(v4blockchain::detail::ST_CHAIN_CF, key);
+  if (!opt_block_str) return std::nullopt;
+  return v4blockchain::detail::Block(*opt_block_str);
+}
+
+concord::util::digest::BlockDigest StChain::getBlockParentDigest(concord::kvbc::BlockId id) const {
+  auto block = getBlock(id);
+  ConcordAssert(block.has_value());
+  return block->parentDigest();
+}
+
+std::optional<std::string> StChain::getBlockData(concord::kvbc::BlockId id) const {
+  auto key = v4blockchain::detail::Blockchain::generateKey(id);
+  return native_client_->get(v4blockchain::detail::ST_CHAIN_CF, key);
 }
 
 }  // namespace concord::kvbc::v4blockchain::detail

--- a/kvbc/src/v4blockchain/v4_blockchain.cpp
+++ b/kvbc/src/v4blockchain/v4_blockchain.cpp
@@ -17,6 +17,7 @@
 #include "categorization/db_categories.h"
 #include "kvbc_key_types.hpp"
 #include "block_metadata.hpp"
+#include "throughput.hpp"
 
 namespace concord::kvbc::v4blockchain {
 
@@ -29,8 +30,22 @@ KeyValueBlockchain::KeyValueBlockchain(
     : native_client_{native_client},
       block_chain_{native_client_},
       state_transfer_chain_{native_client_},
-      latest_keys_{native_client_, category_types, [&]() { return block_chain_.getGenesisBlockId(); }} {}
+      latest_keys_{native_client_, category_types, [&]() { return block_chain_.getGenesisBlockId(); }} {
+  if (!link_st_chain || state_transfer_chain_.getLastBlockId() == 0) return;
+  // Make sure that if linkSTChainFrom() has been interrupted (e.g. a crash or an abnormal shutdown), all DBAdapter
+  // methods will return the correct values. For example, if state transfer had completed and linkSTChainFrom() was
+  // interrupted, getLatestBlockId() should be equal to getLastReachableBlockId() on the next startup. Another example
+  // is getValue() that returns keys from the blockchain only and ignores keys in the temporary state
+  // transfer chain.
+  LOG_INFO(V4_BLOCK_LOG, "Try to link ST temporary chain, this might take some time...");
+  auto old_last_reachable_block_id = getLastReachableBlockId();
+  linkSTChain();
+  auto new_last_reachable_block_id = getLastReachableBlockId();
+  LOG_INFO(V4_BLOCK_LOG,
+           "Done linking ST temporary chain:" << KVLOG(old_last_reachable_block_id, new_last_reachable_block_id));
+}
 
+//////////////////////////// ADDER////////////////////////////////////////////
 /*
   1 - check if we can perform GC on latest CF
   2 - add the block to the blocks CF
@@ -42,24 +57,31 @@ BlockId KeyValueBlockchain::add(categorization::Updates&& updates) {
   auto scoped = v4blockchain::detail::ScopedDuration{"Add block"};
   // Should be performed before we add the block with the current Updates.
   auto sequence_number = markHistoryForGarbageCollectionIfNeeded(updates);
-
   auto write_batch = native_client_->getBatch();
   // addGenesisBlockKey(updates);
-  BlockId block_id{};
-  {
-    auto scoped2 = v4blockchain::detail::ScopedDuration{"Add block to blockchain"};
-    block_id = block_chain_.addBlock(updates, write_batch);
-  }
+  auto block_id = add(updates, write_batch);
 
-  {
-    auto scoped3 = v4blockchain::detail::ScopedDuration{"Add block to latest"};
-    latest_keys_.addBlockKeys(updates, block_id, write_batch);
-  }
   native_client_->write(std::move(write_batch));
   block_chain_.setBlockId(block_id);
   if (sequence_number > 0) setLastBlockSequenceNumber(sequence_number);
   return block_id;
 }
+
+BlockId KeyValueBlockchain::add(const categorization::Updates& updates,
+                                storage::rocksdb::NativeWriteBatch& write_batch) {
+  BlockId block_id{};
+  {
+    auto scoped2 = v4blockchain::detail::ScopedDuration{"Add block to blockchain"};
+    block_id = block_chain_.addBlock(updates, write_batch);
+  }
+  {
+    auto scoped3 = v4blockchain::detail::ScopedDuration{"Add block to latest"};
+    latest_keys_.addBlockKeys(updates, block_id, write_batch);
+  }
+  return block_id;
+}
+
+//////////////////////////// DELETER////////////////////////////////////////////
 
 BlockId KeyValueBlockchain::deleteBlocksUntil(BlockId until) {
   auto scoped = v4blockchain::detail::ScopedDuration{"deleteBlocksUntil"};
@@ -142,4 +164,179 @@ void KeyValueBlockchain::addGenesisBlockKey(categorization::Updates& updates) co
       categorization::VersionedUpdates::ValueType{
           concordUtils::toBigEndianStringBuffer(block_chain_.getGenesisBlockId()), stale_on_update});
 }
+
+///////////// STATE TRANSFER////////////////////////
+bool KeyValueBlockchain::hasBlock(BlockId block_id) const {
+  const auto last_reachable_block = block_chain_.getLastReachable();
+  if (block_id > last_reachable_block) {
+    return state_transfer_chain_.hasBlock(block_id);
+  }
+  return block_chain_.hasBlock(block_id);
+}
+
+std::optional<std::string> KeyValueBlockchain::getBlockData(const BlockId& block_id) const {
+  const auto last_reachable_block = getLastReachableBlockId();
+  // Try to take it from the ST chain
+  if (block_id > last_reachable_block) {
+    return state_transfer_chain_.getBlockData(block_id);
+  }
+  // Try from the blockchain itself
+  return block_chain_.getBlockData(block_id);
+}
+
+std::optional<BlockId> KeyValueBlockchain::getLastStatetransferBlockId() const {
+  if (state_transfer_chain_.getLastBlockId() == 0) return std::nullopt;
+  return state_transfer_chain_.getLastBlockId();
+}
+
+concord::util::digest::BlockDigest KeyValueBlockchain::parentDigest(BlockId block_id) const {
+  const auto last_reachable_block = getLastReachableBlockId();
+  if (block_id > last_reachable_block) {
+    return state_transfer_chain_.getBlockParentDigest(block_id);
+  }
+  if (block_id < getGenesisBlockId()) {
+    LOG_ERROR(V4_BLOCK_LOG,
+              "Trying to get digest from block " << block_id << " while genesis is " << getGenesisBlockId());
+    concord::util::digest::BlockDigest empty_digest;
+    empty_digest.fill(0);
+    return empty_digest;
+  }
+  return block_chain_.getBlockParentDigest(block_id);
+}
+
+//
+void KeyValueBlockchain::addBlockToSTChain(const BlockId& block_id,
+                                           const char* block,
+                                           const uint32_t block_size,
+                                           bool last_block) {
+  const auto last_reachable_block = getLastReachableBlockId();
+  if (block_id <= last_reachable_block) {
+    const auto msg = "Cannot add an existing block ID " + std::to_string(block_id);
+    throw std::invalid_argument{msg};
+  }
+
+  if (state_transfer_chain_.hasBlock(block_id)) {
+    auto existing_block = state_transfer_chain_.getBlockData(block_id);
+    ConcordAssert(existing_block.has_value());
+    auto view = std::string_view{block, block_size};
+    if (view != *existing_block) {
+      LOG_ERROR(V4_BLOCK_LOG,
+                "found existing (and different) block ID[" << block_id << "] when receiving from state transfer");
+
+      // E.L I think it's dangerous to delete the block and there is no value in doing so
+      // kvbc_->deleteBlock(blockId);
+      throw std::runtime_error(
+          __PRETTY_FUNCTION__ +
+          std::string("found existing (and different) block when receiving state transfer, block ID: ") +
+          std::to_string(block_id));
+    }
+    return;
+  }
+
+  state_transfer_chain_.addBlock(block_id, block, block_size);
+  if (last_block) {
+    try {
+      linkSTChain();
+    } catch (const std::exception& e) {
+      LOG_FATAL(V4_BLOCK_LOG,
+                "Aborting due to failure to link chains after block has been added, reason: " << e.what());
+      std::terminate();
+    } catch (...) {
+      LOG_FATAL(V4_BLOCK_LOG, "Aborting due to failure to link chains after block has been added");
+      std::terminate();
+    }
+  }
+}
+
+void KeyValueBlockchain::linkSTChain() {
+  BlockId block_id = getLastReachableBlockId() + 1;
+  const auto last_block_id = state_transfer_chain_.getLastBlockId();
+  if (last_block_id == 0) return;
+
+  for (auto i = block_id; i <= last_block_id; ++i) {
+    auto block = state_transfer_chain_.getBlock(i);
+    if (!block) {
+      return;
+    }
+    auto updates = block->getUpdates();
+    writeSTLinkTransaction(i, updates);
+  }
+  // Linking has fully completed and we should not have any more ST temporary blocks left. Therefore, make sure we don't
+  // have any value for the latest ST temporary block ID cache.
+  state_transfer_chain_.resetChain();
+}
+
+void KeyValueBlockchain::pruneOnSTLink(const categorization::Updates& updates) {
+  auto cat_it = updates.categoryUpdates().kv.find(categorization::kConcordInternalCategoryId);
+  if (cat_it == updates.categoryUpdates().kv.cend()) {
+    return;
+  }
+  const auto& internal_kvs = std::get<categorization::VersionedInput>(cat_it->second).kv;
+  auto key_it = internal_kvs.find(keyTypes::genesis_block_key);
+  if (key_it != internal_kvs.cend()) {
+    const auto block_genesis_id = concordUtils::fromBigEndianBuffer<BlockId>(key_it->second.data.data());
+    while (getGenesisBlockId() >= INITIAL_GENESIS_BLOCK_ID && getGenesisBlockId() < getLastReachableBlockId() &&
+           block_genesis_id > getGenesisBlockId()) {
+      deleteGenesisBlock();
+    }
+  }
+}
+
+// Atomic delete from state transfer and add to blockchain
+void KeyValueBlockchain::writeSTLinkTransaction(const BlockId block_id, const categorization::Updates& updates) {
+  auto sequence_number = markHistoryForGarbageCollectionIfNeeded(updates);
+  auto write_batch = native_client_->getBatch();
+  state_transfer_chain_.deleteBlock(block_id, write_batch);
+  auto new_block_id = add(updates, write_batch);
+  native_client_->write(std::move(write_batch));
+  block_chain_.setBlockId(new_block_id);
+  pruneOnSTLink(updates);
+  if (sequence_number > 0) setLastBlockSequenceNumber(sequence_number);
+}
+
+size_t KeyValueBlockchain::linkUntilBlockId(BlockId until_block_id) {
+  const auto from_block_id = getLastReachableBlockId() + 1;
+  ConcordAssertLE(from_block_id, until_block_id);
+
+  static constexpr uint64_t report_thresh{1000};
+  static uint64_t report_counter{};
+
+  concord::util::DurationTracker<std::chrono::milliseconds> link_duration("link_duration", true);
+  BlockId last_added = 0;
+  for (auto i = from_block_id; i <= until_block_id; ++i) {
+    auto block = state_transfer_chain_.getBlock(i);
+
+    if (!block) break;
+    last_added = i;
+    // First prune and then link the block to the chain. Rationale is that this will preserve the same order of block
+    // deletes relative to block adds on source and destination replicas.
+    auto updates = block->getUpdates();
+    writeSTLinkTransaction(i, updates);
+    if ((++report_counter % report_thresh) == 0) {
+      auto elapsed_time_ms = link_duration.totalDuration();
+      uint64_t blocks_linked_per_sec{};
+      uint64_t blocks_left_to_link{};
+      uint64_t estimated_time_left_sec{};
+      if (elapsed_time_ms > 0) {
+        blocks_linked_per_sec = (((i - from_block_id + 1) * 1000) / (elapsed_time_ms));
+        blocks_left_to_link = until_block_id - i;
+        estimated_time_left_sec = blocks_left_to_link / blocks_linked_per_sec;
+      }
+      LOG_INFO(CAT_BLOCK_LOG,
+               "Last block ID connected: " << i << ","
+                                           << KVLOG(from_block_id,
+                                                    until_block_id,
+                                                    elapsed_time_ms,
+                                                    blocks_linked_per_sec,
+                                                    blocks_left_to_link,
+                                                    estimated_time_left_sec));
+    }
+  }
+  if (last_added == state_transfer_chain_.getLastBlockId()) {
+    LOG_INFO(V4_BLOCK_LOG, "Added all blocks in st chain, until block " << last_added << " resetting chain");
+    state_transfer_chain_.resetChain();
+  }
+  return (last_added - from_block_id) + 1;
+}
+
 }  // namespace concord::kvbc::v4blockchain

--- a/kvbc/test/CMakeLists.txt
+++ b/kvbc/test/CMakeLists.txt
@@ -245,6 +245,18 @@ if (BUILD_ROCKSDB_STORAGE)
         stdc++fs
     )
 
+    add_executable(v4_st_chain_unit_test
+        v4blockchain/st_chain_test.cpp )
+    add_test(v4_st_chain_unit_test v4_st_chain_unit_test)
+    target_link_libraries(v4_st_chain_unit_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        util
+        corebft
+        kvbc
+        stdc++fs
+    )
+
     add_executable(v4_categories_unit_test
         v4blockchain/categories_test.cpp )
     add_test(v4_categories_unit_test v4_categories_unit_test)
@@ -273,6 +285,18 @@ if (BUILD_ROCKSDB_STORAGE)
         v4blockchain/blockchain_test.cpp )
     add_test(v4_blockchain_unit_test v4_blockchain_unit_test)
     target_link_libraries(v4_blockchain_unit_test PUBLIC
+        GTest::Main
+        GTest::GTest
+        util
+        corebft
+        kvbc
+        stdc++fs
+    )
+
+    add_executable(app_state_adapter_test
+    kvbc_adapter/v4blockchain/app_state_adapter_test.cpp )
+    add_test(app_state_adapter_test app_state_adapter_test)
+    target_link_libraries(app_state_adapter_test PUBLIC
         GTest::Main
         GTest::GTest
         util

--- a/kvbc/test/kvbc_adapter/v4blockchain/app_state_adapter_test.cpp
+++ b/kvbc/test/kvbc_adapter/v4blockchain/app_state_adapter_test.cpp
@@ -1,0 +1,116 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "v4blockchain/v4_blockchain.h"
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+#include <random>
+#include "storage/test/storage_test_common.h"
+#include "endianness.hpp"
+#include "v4blockchain/detail/st_chain.h"
+#include "kvbc_adapter/v4blockchain/app_state_adapter.hpp"
+#include "v4blockchain/v4_blockchain.h"
+#include <memory>
+#include "db_adapter_interface.h"
+
+using concord::storage::rocksdb::NativeClient;
+using namespace concord::kvbc;
+using namespace ::testing;
+using namespace concord;
+
+namespace {
+
+class v4_kvbc : public Test {
+ protected:
+  void SetUp() override {
+    destroyDb();
+    db = TestRocksDb::createNative();
+    categories = std::map<std::string, categorization::CATEGORY_TYPE>{
+        {"merkle", categorization::CATEGORY_TYPE::block_merkle},
+        {"versioned", categorization::CATEGORY_TYPE::versioned_kv},
+        {"versioned_2", categorization::CATEGORY_TYPE::versioned_kv},
+        {"immutable", categorization::CATEGORY_TYPE::immutable}};
+    bc = std::make_shared<v4blockchain::KeyValueBlockchain>(db, true, categories);
+  }
+
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    db.reset();
+    ASSERT_EQ(0, db.use_count());
+    cleanup();
+  }
+
+ protected:
+  std::map<std::string, categorization::CATEGORY_TYPE> categories;
+  std::shared_ptr<NativeClient> db;
+  std::shared_ptr<v4blockchain::KeyValueBlockchain> bc;
+};
+
+TEST_F(v4_kvbc, put_get_blocks) {
+  auto state_adapter = concord::kvbc::adapter::v4blockchain::AppStateAdapter{bc};
+  char buffer[1000];
+  uint32_t out = 0;
+  ASSERT_EQ(state_adapter.getLastBlockNum(), 0);
+  // Add block to blockchain and validate get
+  ASSERT_FALSE(state_adapter.hasBlock(1));
+  categorization::Updates updates;
+  categorization::BlockMerkleUpdates merkle_updates;
+  merkle_updates.addUpdate("merkle_key1", "merkle_value1");
+  merkle_updates.addUpdate("merkle_key2", "merkle_value2");
+  updates.add("merkle", std::move(merkle_updates));
+
+  categorization::VersionedUpdates ver_updates;
+  ver_updates.calculateRootHash(true);
+  ver_updates.addUpdate("ver_key1", "ver_val1");
+  ver_updates.addUpdate("ver_key2", categorization::VersionedUpdates::Value{"ver_val2", true});
+  updates.add("versioned", std::move(ver_updates));
+  auto updates_copy = updates;
+  ASSERT_EQ(bc->add(std::move(updates)), (BlockId)1);
+  ASSERT_TRUE(state_adapter.hasBlock(1));
+  ASSERT_EQ(state_adapter.getLastBlockNum(), 1);
+
+  ASSERT_TRUE(state_adapter.getBlock(1, buffer, 1000, &out));
+  auto strblock1 = std::string(buffer, out);
+  auto block1 = ::v4blockchain::detail::Block{strblock1};
+  auto getUpdates = block1.getUpdates();
+  ASSERT_EQ(getUpdates, updates_copy);
+
+  // Add block to ST chain
+  auto block = std::string("block");
+  auto blockDiff = std::string("blockDiff");
+  state_adapter.putBlock(8, block.c_str(), block.size(), false);
+  ASSERT_TRUE(state_adapter.hasBlock(8));
+  ASSERT_EQ(state_adapter.getLastBlockNum(), 8);
+
+  // try to add existing st block with different content
+  ASSERT_THROW(state_adapter.putBlock(8, blockDiff.c_str(), blockDiff.size(), false), std::runtime_error);
+  // not found
+  ASSERT_THROW(state_adapter.getBlock(2, buffer, 1000, &out), kvbc::NotFoundException);
+  // buffer too small
+  ASSERT_THROW(state_adapter.getBlock(8, buffer, 1, &out), std::runtime_error);
+  ASSERT_TRUE(state_adapter.getBlock(8, buffer, 1000, &out));
+  auto getBlock = std::string(buffer, out);
+  ASSERT_EQ(getBlock, block);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/kvbc/test/v4blockchain/st_chain_test.cpp
+++ b/kvbc/test/v4blockchain/st_chain_test.cpp
@@ -1,0 +1,200 @@
+// Concord
+//
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "v4blockchain/v4_blockchain.h"
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+#include <random>
+#include "storage/test/storage_test_common.h"
+#include "endianness.hpp"
+#include "v4blockchain/detail/st_chain.h"
+
+using concord::storage::rocksdb::NativeClient;
+using namespace concord::kvbc;
+using namespace ::testing;
+using namespace concord;
+
+namespace {
+
+class v4_kvbc : public Test {
+ protected:
+  void SetUp() override {
+    destroyDb();
+    db = TestRocksDb::createNative();
+    categories = std::map<std::string, categorization::CATEGORY_TYPE>{
+        {"merkle", categorization::CATEGORY_TYPE::block_merkle},
+        {"versioned", categorization::CATEGORY_TYPE::versioned_kv},
+        {"versioned_2", categorization::CATEGORY_TYPE::versioned_kv},
+        {"immutable", categorization::CATEGORY_TYPE::immutable}};
+  }
+
+  void TearDown() override { destroyDb(); }
+
+  void destroyDb() {
+    db.reset();
+    ASSERT_EQ(0, db.use_count());
+    cleanup();
+  }
+
+ protected:
+  std::map<std::string, categorization::CATEGORY_TYPE> categories;
+  std::shared_ptr<NativeClient> db;
+};
+
+TEST_F(v4_kvbc, blocks) {
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    auto id1 = kvbc::BlockId{1};
+    auto block1 = std::string{"block1"};
+    ASSERT_TRUE(db->hasColumnFamily(v4blockchain::detail::ST_CHAIN_CF));
+    ASSERT_FALSE(st_chain.hasBlock(id1));
+    { st_chain.addBlock(id1, block1.c_str(), block1.size()); }
+
+    ASSERT_TRUE(st_chain.hasBlock(id1));
+
+    {
+      auto write_batch = db->getBatch();
+      st_chain.deleteBlock(id1, write_batch);
+      db->write(std::move(write_batch));
+    }
+    ASSERT_FALSE(st_chain.hasBlock(id1));
+  }
+}
+
+TEST_F(v4_kvbc, get_blocks) {
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    auto id1 = kvbc::BlockId{1};
+    auto block1_str = std::string{"block1"};
+    auto block1 = v4blockchain::detail::Block(block1_str);
+    ASSERT_TRUE(db->hasColumnFamily(v4blockchain::detail::ST_CHAIN_CF));
+    ASSERT_FALSE(st_chain.getBlock(id1).has_value());
+    ASSERT_FALSE(st_chain.getBlockData(id1).has_value());
+    { st_chain.addBlock(id1, block1_str.c_str(), block1_str.size()); }
+    auto opt_block = st_chain.getBlock(id1);
+    ASSERT_TRUE(opt_block.has_value());
+    ASSERT_EQ(opt_block->getBuffer(), block1.getBuffer());
+    auto opt_block_data = st_chain.getBlockData(id1);
+    ASSERT_TRUE(opt_block_data.has_value());
+    ASSERT_EQ(*opt_block_data, block1_str);
+
+    {
+      auto write_batch = db->getBatch();
+      st_chain.deleteBlock(id1, write_batch);
+      db->write(std::move(write_batch));
+    }
+
+    ASSERT_FALSE(st_chain.getBlock(id1).has_value());
+    ASSERT_FALSE(st_chain.getBlockData(id1).has_value());
+  }
+}
+
+TEST_F(v4_kvbc, load_block_id) {
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    ASSERT_EQ(st_chain.getLastBlockId(), 0);
+  }
+  auto id1 = kvbc::BlockId{1};
+  auto id5 = kvbc::BlockId{5};
+  auto block_buff = std::string{"block1"};
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    auto block1 = std::string{"block1"};
+    ASSERT_TRUE(db->hasColumnFamily(v4blockchain::detail::ST_CHAIN_CF));
+    st_chain.addBlock(id1, block_buff.c_str(), block_buff.size());
+  }
+
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    ASSERT_EQ(st_chain.getLastBlockId(), id1);
+    st_chain.addBlock(id5, block_buff.c_str(), block_buff.size());
+  }
+
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    ASSERT_EQ(st_chain.getLastBlockId(), id5);
+  }
+}
+
+TEST_F(v4_kvbc, update_block_id) {
+  auto id1 = kvbc::BlockId{1};
+  auto id3 = kvbc::BlockId{3};
+  auto id5 = kvbc::BlockId{5};
+  auto id7 = kvbc::BlockId{7};
+  auto block_buff = std::string{"block1"};
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    auto block1 = std::string{"block1"};
+    ASSERT_TRUE(db->hasColumnFamily(v4blockchain::detail::ST_CHAIN_CF));
+    st_chain.addBlock(id1, block_buff.c_str(), block_buff.size());
+  }
+  // delete the single block
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    ASSERT_EQ(st_chain.getLastBlockId(), id1);
+    auto write_batch = db->getBatch();
+    st_chain.deleteBlock(id1, write_batch);
+    db->write(std::move(write_batch));
+    st_chain.updateLastIdAfterDeletion(id1);
+    ASSERT_EQ(st_chain.getLastBlockId(), 0);
+  }
+
+  // load an empty chain and add a new block.
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    ASSERT_EQ(st_chain.getLastBlockId(), 0);
+    auto block1 = std::string{"block1"};
+    ASSERT_TRUE(db->hasColumnFamily(v4blockchain::detail::ST_CHAIN_CF));
+    st_chain.addBlock(id1, block_buff.c_str(), block_buff.size());
+  }
+
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    ASSERT_EQ(st_chain.getLastBlockId(), id1);
+    st_chain.addBlock(id5, block_buff.c_str(), block_buff.size());
+    st_chain.updateLastIdAfterDeletion(id5);
+    ASSERT_EQ(st_chain.getLastBlockId(), id5);
+  }
+
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    ASSERT_EQ(st_chain.getLastBlockId(), id5);
+    st_chain.updateLastIdIfBigger(id3);
+    ASSERT_EQ(st_chain.getLastBlockId(), id5);
+    st_chain.updateLastIdIfBigger(id7);
+    ASSERT_EQ(st_chain.getLastBlockId(), id7);
+  }
+  // load reads the actual idx from storage
+  {
+    auto st_chain = v4blockchain::detail::StChain{db};
+    ASSERT_EQ(st_chain.getLastBlockId(), id5);
+    st_chain.updateLastIdAfterDeletion(id3);
+    ASSERT_EQ(st_chain.getLastBlockId(), id5);
+    auto write_batch = db->getBatch();
+    st_chain.deleteBlock(id5, write_batch);
+    db->write(std::move(write_batch));
+    st_chain.updateLastIdAfterDeletion(id5);
+    ASSERT_EQ(st_chain.getLastBlockId(), id1);
+  }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Add the operations to manage the state transfer chain.

Implementing the storage IAppState interface that basically knows how to add blocks to the state-transfer chain and to
move blocks from the state-transfer chain to the blockchain.

Tests:
UT for all the methods.