### PR TITLE
Apollo test to run for both V4 and V1

### DIFF
--- a/tests/apollo/CMakeLists.txt
+++ b/tests/apollo/CMakeLists.txt
@@ -46,179 +46,151 @@ endif()
 set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} KEEP_APOLLO_LOGS=${KEEP_APOLLO_LOGS}")
 set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} TXN_SIGNING_ENABLED=${TXN_SIGNING_ENABLED}")
 set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} TIME_SERVICE_ENABLED=TRUE")
-set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=1")
 set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} USE_FAKE_CLOCK_IN_TIME_SERVICE=${USE_FAKE_CLOCK_IN_TIME_SERVICE}")
 
 if (OMIT_TEST_OUTPUT)
     set(TEST_OUTPUT "2>&1 > /dev/null")
 endif()
 
-add_test(NAME skvbc_basic_tests COMMAND sh -c
+set(BLOCKCHAINVERSION 1 4)
+foreach(VER IN LISTS BLOCKCHAINVERSION)
+    set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=${VER}")
+    add_test(NAME skvbc_basic_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_basic_tests python3 -m unittest test_skvbc ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=4")
-add_test(NAME skvbc_basic_tests_v4 COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_basic_tests python3 -m unittest test_skvbc ${TEST_OUTPUT}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=1")
-
-
-if (BUILD_ROCKSDB_STORAGE)
-    add_test(NAME skvbc_persistence_tests COMMAND sh -c
+    if (BUILD_ROCKSDB_STORAGE)
+        add_test(NAME skvbc_persistence_tests_${VER} COMMAND sh -c
             "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_persistence_tests python3 -m unittest test_skvbc_persistence ${TEST_OUTPUT}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-    set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=4")
-    add_test(NAME skvbc_persistence_tests_v4 COMMAND sh -c
-            "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_persistence_tests python3 -m unittest test_skvbc_persistence ${TEST_OUTPUT}"
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-    set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=1")
-
-    if (USE_S3_OBJECT_STORE)
-        add_test(NAME skvbc_ro_replica_tests_1 COMMAND sh -c
+        if (USE_S3_OBJECT_STORE)
+            add_test(NAME skvbc_ro_replica_tests_${VER} COMMAND sh -c
                 "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_ro_replica_tests python3 -m unittest test_skvbc_ro_replica ${TEST_OUTPUT}"
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-        add_test(NAME skvbc_s3_integrity_check_tests_1 COMMAND sh -c
+            add_test(NAME skvbc_s3_integrity_check_tests_${VER} COMMAND sh -c
                 "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_s3_integrity_check_tests python3 -m unittest test_skvbc_s3_integrity_check ${TEST_OUTPUT}"
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-        set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=4")
-        add_test(NAME skvbc_ro_replica_tests_4 COMMAND sh -c
-                "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_ro_replica_tests python3 -m unittest test_skvbc_ro_replica ${TEST_OUTPUT}"
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-        add_test(NAME skvbc_s3_integrity_check_tests_4 COMMAND sh -c
-                "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_s3_integrity_check_tests python3 -m unittest test_skvbc_s3_integrity_check ${TEST_OUTPUT}"
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-        set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=1")
+        endif()
     endif()
-endif()
 
-if (USE_S3_OBJECT_STORE AND BUILD_COMM_TCP_TLS AND TXN_SIGNING_ENABLED)
-    add_test(NAME skvbc_reconfiguration COMMAND sh -c
+    if (USE_S3_OBJECT_STORE AND BUILD_COMM_TCP_TLS AND TXN_SIGNING_ENABLED)
+        add_test(NAME skvbc_reconfiguration_${VER} COMMAND sh -c
             "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_reconfiguration python3 -m unittest test_skvbc_reconfiguration ${TEST_OUTPUT}"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-endif()
+    endif()
 
-add_test(NAME skvbc_multi_sig COMMAND sh -c
+    add_test(NAME skvbc_multi_sig_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_multi_sig python3 -m unittest test_skvbc_multi_sig ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_linearizability_tests COMMAND sudo sh -c
+    add_test(NAME skvbc_linearizability_tests_${VER} COMMAND sudo sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_linearizability_tests python3 -m unittest test_skvbc_linearizability ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME test_skvbc_history_tracker COMMAND sudo sh -c
+    add_test(NAME test_skvbc_history_tracker_${VER} COMMAND sudo sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=test_skvbc_history_tracker python3 -m unittest test_skvbc_history_tracker ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_commit_path_tests COMMAND sh -c
+    add_test(NAME skvbc_commit_path_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_commit_path_tests python3 -m unittest test_skvbc_commit_path ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_view_change_tests COMMAND sudo sh -c
+    add_test(NAME skvbc_view_change_tests_${VER} COMMAND sudo sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_view_change_tests python3 -m unittest test_skvbc_view_change ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_auto_view_change_tests COMMAND sh -c
+    add_test(NAME skvbc_auto_view_change_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_auto_view_change_tests python3 -m unittest test_skvbc_auto_view_change ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-# add_test(NAME skvbc_state_transfer_tests COMMAND sh -c
-#         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_state_transfer_tests python3 -m unittest test_skvbc_state_transfer ${TEST_OUTPUT}"
-#         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=4")
-add_test(NAME skvbc_state_transfer_tests_v4 COMMAND sh -c
+    add_test(NAME skvbc_state_transfer_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_state_transfer_tests python3 -m unittest test_skvbc_state_transfer ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=1")
 
-# PreExecution tests are executed two times - with PreExecution Result Authentication enabled and disabled.
-add_test(NAME skvbc_preexecution_tests COMMAND sh -c
+    # PreExecution tests are executed two times - with PreExecution Result Authentication enabled and disabled.
+    add_test(NAME skvbc_preexecution_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_preexecution_tests python3 -m unittest test_skvbc_preexecution ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-add_test(NAME skvbc_preexecution_with_result_auth_tests COMMAND sh -c
+    add_test(NAME skvbc_preexecution_with_result_auth_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} PRE_EXEC_RESULT_AUTH_ENABLED=True TEST_NAME=skvbc_preexecution_with_result_auth_tests python3 -m unittest test_skvbc_preexecution ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_batch_preexecution_tests COMMAND sh -c
+    add_test(NAME skvbc_batch_preexecution_tests_${VER} COMMAND sh -c
           "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_batch_preexecution_tests python3 -m unittest test_skvbc_batch_preexecution ${TEST_OUTPUT}"
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_network_partitioning_tests COMMAND sh -c
+    add_test(NAME skvbc_network_partitioning_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_network_partitioning_tests python3 -m unittest test_skvbc_network_partitioning ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_checkpoints COMMAND sh -c
+    add_test(NAME skvbc_checkpoints_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_checkpoints python3 -m unittest test_skvbc_checkpoints 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_chaotic_startup COMMAND sudo sh -c
+    add_test(NAME skvbc_chaotic_startup_${VER} COMMAND sudo sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_chaotic_startup python3 -m unittest test_skvbc_chaotic_startup 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_publish_clients_keys COMMAND sudo sh -c
+    add_test(NAME skvbc_publish_clients_keys_${VER} COMMAND sudo sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_publish_clients_keys python3 -m unittest test_skvbc_publish_clients_keys 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_backup_restore COMMAND sh -c
+    add_test(NAME skvbc_backup_restore_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_backup_restore python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=4")
-add_test(NAME skvbc_backup_restore_v4 COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_backup_restore python3 -m unittest test_skvbc_backup_restore 2>&1 > /dev/null"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-set(APOLLO_TEST_ENV "${APOLLO_TEST_ENV} BLOCKCHAIN_VERSION=1")
-
-
-add_test(NAME skvbc_consensus_batching COMMAND sh -c
+    add_test(NAME skvbc_consensus_batching_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_consensus_batching python3 -m unittest test_skvbc_consensus_batching ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_block_accumulation_tests COMMAND sh -c
+    add_test(NAME skvbc_block_accumulation_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_block_accumulation_tests python3 -m unittest test_skvbc_block_accumulation ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-# Disabled - see BC-19213
-# if (TXN_SIGNING_ENABLED)
-#     add_test(NAME skvbc_client_transaction_signing COMMAND sh -c
-#             "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_client_transaction_signing python3 -m unittest test_skvbc_client_transaction_signing ${TEST_OUTPUT}"
-#             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-# endif()
+    # Disabled - see BC-19213
+    # if (TXN_SIGNING_ENABLED)
+    #     add_test(NAME skvbc_client_transaction_signing_${VER} COMMAND sh -c
+    #             "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_client_transaction_signing python3 -m unittest test_skvbc_client_transaction_signing ${TEST_OUTPUT}"
+    #             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    # endif()
 
-add_test(NAME skvbc_pyclient_tests COMMAND sh -c
+    add_test(NAME skvbc_pyclient_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_pyclient_tests python3 -m unittest test_skvbc_pyclient ${TEST_OUTPUT}"
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_cron COMMAND sh -c
+    add_test(NAME skvbc_cron_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_cron python3 -m unittest test_skvbc_cron ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_byzantine_primary_preexecution_tests COMMAND sh -c
+    add_test(NAME skvbc_byzantine_primary_preexecution_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_byzantine_primary_preexecution_tests python3 -m unittest test_skvbc_byzantine_primary_preexecution ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-if (USE_FAKE_CLOCK_IN_TIME_SERVICE)        
-    add_test(NAME skvbc_time_service COMMAND sh -c
+    if (USE_FAKE_CLOCK_IN_TIME_SERVICE)
+        add_test(NAME skvbc_time_service_${VER} COMMAND sh -c
               "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_time_service python3 -m unittest test_skvbc_time_service ${TEST_OUTPUT}"
               WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-endif()
+    endif()
 
-add_test(NAME skvbc_dbsnapshot_tests COMMAND sh -c
+    add_test(NAME skvbc_dbsnapshot_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_dbsnapshot_tests python3 -m unittest test_skvbc_dbsnapshot ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_reply_tests COMMAND sh -c
+    add_test(NAME skvbc_reply_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_reply_tests python3 -m unittest test_skvbc_reply ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_test(NAME skvbc_diagnostics_tests COMMAND sh -c
+    add_test(NAME skvbc_diagnostics_tests_${VER} COMMAND sh -c
         "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_diagnostics_tests python3 -m unittest test_skvbc_diagnostics ${TEST_OUTPUT}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-if(ENABLE_RESTART_RECOVERY_TESTS)
-add_test(NAME skvbc_restart_recovery_tests COMMAND sh -c
-        "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_restart_recovery_tests python3 -m unittest test_skvbc_restart_recovery ${TEST_OUTPUT}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-endif()
+    if(ENABLE_RESTART_RECOVERY_TESTS)
+        add_test(NAME skvbc_restart_recovery_tests_${VER} COMMAND sh -c
+                "env ${APOLLO_TEST_ENV} BUILD_COMM_TCP_TLS=${BUILD_COMM_TCP_TLS} TEST_NAME=skvbc_restart_recovery_tests python3 -m unittest test_skvbc_restart_recovery ${TEST_OUTPUT}"
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    endif()
+endforeach()
+
+
+

--- a/tests/apollo/test_skvbc_auto_view_change.py
+++ b/tests/apollo/test_skvbc_auto_view_change.py
@@ -29,12 +29,18 @@ def start_replica_cmd(builddir, replica_id):
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "1000"
     autoPrimaryRotationTimeoutMilli = "5000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-a", autoPrimaryRotationTimeoutMilli
             ]
 

--- a/tests/apollo/test_skvbc_batch_preexecution.py
+++ b/tests/apollo/test_skvbc_batch_preexecution.py
@@ -42,11 +42,17 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
 
     status_timer_milli = "500"
 
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", status_timer_milli,
+            "-V", blockchain_version,
             "-v", view_change_timeout_milli
             ]
 

--- a/tests/apollo/test_skvbc_block_accumulation.py
+++ b/tests/apollo/test_skvbc_block_accumulation.py
@@ -43,12 +43,18 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
 
     status_timer_milli = "500"
 
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", status_timer_milli,
             "-v", view_change_timeout_milli,
+            "-V", blockchain_version,
             "-u", str(True)
             ]
 

--- a/tests/apollo/test_skvbc_byzantine_primary_preexecution.py
+++ b/tests/apollo/test_skvbc_byzantine_primary_preexecution.py
@@ -38,12 +38,18 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
 
     status_timer_milli = "500"
 
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     cmd = [path,
            "-k", KEY_FILE_PREFIX,
            "-i", str(replica_id),
            "-s", status_timer_milli,
            "-v", view_change_timeout_milli,
+           "-V", blockchain_version,
            "-x"
            ]
     if replica_id == 0 :
@@ -62,12 +68,18 @@ def start_replica_cmd_asymmetric_communication(builddir, replica_id, view_change
 
     status_timer_milli = "500"
 
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     cmd = [path,
            "-k", KEY_FILE_PREFIX,
            "-i", str(replica_id),
            "-s", status_timer_milli,
            "-v", view_change_timeout_milli,
+           "-V", blockchain_version,
            "-x"
            ]
     if replica_id == 0 :

--- a/tests/apollo/test_skvbc_chaotic_startup.py
+++ b/tests/apollo/test_skvbc_chaotic_startup.py
@@ -32,12 +32,18 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", view_change_timeout_milli
+            "-v", view_change_timeout_milli,
+            "-V", blockchain_version
             ]
 
 

--- a/tests/apollo/test_skvbc_checkpoints.py
+++ b/tests/apollo/test_skvbc_checkpoints.py
@@ -31,12 +31,18 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     params = [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli
+            "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version
             ]
     return params
 
@@ -44,12 +50,18 @@ def build_start_replica_cmd_with_corrupted_checkpoint_msgs(builddir, replica_id,
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
 
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-o", builddir + "/operator_pub.pem",
             "--corrupt-checkpoint-messages-from-replica-id", ",".join(str(replica_id) for \
                     replica_id in corrupt_checkpoints_from_replica_ids)

--- a/tests/apollo/test_skvbc_client_transaction_signing.py
+++ b/tests/apollo/test_skvbc_client_transaction_signing.py
@@ -37,6 +37,11 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     return [path,
@@ -44,6 +49,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-e", str(True)
             ]
 

--- a/tests/apollo/test_skvbc_commit_path.py
+++ b/tests/apollo/test_skvbc_commit_path.py
@@ -45,12 +45,17 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     view_change_timeout_milli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", view_change_timeout_milli,
+            "-V", blockchain_version,
             "-e", str(True)
             ]
 

--- a/tests/apollo/test_skvbc_consensus_batching.py
+++ b/tests/apollo/test_skvbc_consensus_batching.py
@@ -37,6 +37,10 @@ def start_replica_cmd(builddir, replica_id):
     Note each arguments is an element in a list.
     """
     statusTimerMilli = "500"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
@@ -46,7 +50,8 @@ def start_replica_cmd(builddir, replica_id):
             "-b", BATCHING_POLICY,
             "-m", MAX_REQS_SIZE_IN_BATCH,
             "-q", MAX_REQ_NUM_IN_BATCH,
-            "-z", BATCH_FLUSH_PERIOD
+            "-z", BATCH_FLUSH_PERIOD,
+            "-V", blockchain_version
             ]
 
 class SkvbcConsensusBatchingPoliciesTest(ApolloTest):

--- a/tests/apollo/test_skvbc_cron.py
+++ b/tests/apollo/test_skvbc_cron.py
@@ -27,12 +27,17 @@ def start_replica_cmd(builddir, replica_id):
     """
     status_timer_milli = "500"
     view_change_timeout_milli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", status_timer_milli,
             "-v", view_change_timeout_milli,
+            "-V", blockchain_version,
             "-e", str(True),
             "-r", str(expected_number_of_executes)
             ]

--- a/tests/apollo/test_skvbc_dbsnapshot.py
+++ b/tests/apollo/test_skvbc_dbsnapshot.py
@@ -49,6 +49,10 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
@@ -61,6 +65,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-l", os.path.join(builddir, "tests", "simpleKVBC",
                                "scripts", "logging.properties"),
             "-f", time_service_enabled,
@@ -80,6 +85,10 @@ def start_replica_cmd_with_high_db_window_size(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
@@ -93,6 +102,7 @@ def start_replica_cmd_with_high_db_window_size(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-l", os.path.join(builddir, "tests", "simpleKVBC",
                                "scripts", "logging.properties"),
             "-f", time_service_enabled,
@@ -112,6 +122,10 @@ def start_replica_cmd_db_snapshot_disabled(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
@@ -125,6 +139,7 @@ def start_replica_cmd_db_snapshot_disabled(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-l", os.path.join(builddir, "tests", "simpleKVBC",
                                "scripts", "logging.properties"),
             "-f", time_service_enabled,
@@ -143,6 +158,10 @@ def start_replica_cmd_with_operator_and_public_keys(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC",
                         "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true":
@@ -156,6 +175,7 @@ def start_replica_cmd_with_operator_and_public_keys(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-l", os.path.join(builddir, "tests", "simpleKVBC",
                                "scripts", "logging.properties"),
             "-f", time_service_enabled,

--- a/tests/apollo/test_skvbc_diagnostics.py
+++ b/tests/apollo/test_skvbc_diagnostics.py
@@ -58,12 +58,17 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     view_change_timeout_milli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", view_change_timeout_milli,
+            "-V", blockchain_version,
             "-e", str(True),
             "--diagnostics-port", f"{replica_diagnostic_server_port(replica_id)}"
             ]

--- a/tests/apollo/test_skvbc_linearizability.py
+++ b/tests/apollo/test_skvbc_linearizability.py
@@ -35,6 +35,10 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "3000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
 
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
@@ -42,7 +46,8 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
              "-e", str(True),
-            "-v", viewChangeTimeoutMilli
+            "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version
             ]
 
 

--- a/tests/apollo/test_skvbc_multi_sig.py
+++ b/tests/apollo/test_skvbc_multi_sig.py
@@ -29,12 +29,17 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "3000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-e", str(True)
             ]
 

--- a/tests/apollo/test_skvbc_network_partitioning.py
+++ b/tests/apollo/test_skvbc_network_partitioning.py
@@ -33,12 +33,18 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
-            "-v", viewChangeTimeoutMilli
+            "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version
             ]
 
 

--- a/tests/apollo/test_skvbc_persistence.py
+++ b/tests/apollo/test_skvbc_persistence.py
@@ -54,6 +54,10 @@ def start_replica_cmd(builddir, replica_id):
 def start_replica_cmd_with_slowdown(builddir, replica_id):
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
 
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
@@ -61,6 +65,7 @@ def start_replica_cmd_with_slowdown(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "--delay-state-transfer-messages-millisec", '8'
             ]
 

--- a/tests/apollo/test_skvbc_preexecution.py
+++ b/tests/apollo/test_skvbc_preexecution.py
@@ -46,12 +46,18 @@ def start_replica_cmd(builddir, replica_id, view_change_timeout_milli="10000"):
     # Decide from the environment if PreExecution result authentication feature should be enabled or not
     pre_exec_result_auth_enabled = os.environ.get("PRE_EXEC_RESULT_AUTH_ENABLED", default="False").lower() == "true"
 
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", status_timer_milli,
             "-v", view_change_timeout_milli,
+            "-V", blockchain_version,
             "-x" if pre_exec_result_auth_enabled else ""
             ]
 

--- a/tests/apollo/test_skvbc_publish_clients_keys.py
+++ b/tests/apollo/test_skvbc_publish_clients_keys.py
@@ -31,12 +31,18 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-w", str(True)
             ]
 

--- a/tests/apollo/test_skvbc_pyclient.py
+++ b/tests/apollo/test_skvbc_pyclient.py
@@ -42,12 +42,18 @@ def start_replica_cmd(builddir, replica_id):
     Note each argument is an element in a list.
     """
     status_timer_milli = "500"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
+
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", \
         "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", status_timer_milli,
+            "-V", blockchain_version
             ]
 
 class SkvbcPyclientTest(ApolloTest):

--- a/tests/apollo/test_skvbc_reconfiguration.py
+++ b/tests/apollo/test_skvbc_reconfiguration.py
@@ -76,6 +76,10 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true" :
         time_service_enabled = "1"
@@ -88,6 +92,7 @@ def start_replica_cmd(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-l", os.path.join(builddir, "tests", "simpleKVBC", "scripts", "logging.properties"),
             "-f", time_service_enabled,
             "-b", "2",
@@ -105,6 +110,10 @@ def start_replica_cmd_with_key_exchange(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     if os.environ.get('TIME_SERVICE_ENABLED', default="FALSE").lower() == "true" :
         time_service_enabled = "1"
@@ -117,6 +126,7 @@ def start_replica_cmd_with_key_exchange(builddir, replica_id):
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-l", os.path.join(builddir, "tests", "simpleKVBC", "scripts", "logging.properties"),
             "-f", time_service_enabled,
             "-b", "2",

--- a/tests/apollo/test_skvbc_reply.py
+++ b/tests/apollo/test_skvbc_reply.py
@@ -34,12 +34,17 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-e", str(True)
             ]
 

--- a/tests/apollo/test_skvbc_restart_recovery.py
+++ b/tests/apollo/test_skvbc_restart_recovery.py
@@ -35,12 +35,17 @@ def start_replica_cmd(builddir, replica_id):
     global viewChangeTimeoutSec
     statusTimerMilli = "100"
     viewChangeTimeoutMilli = "{}".format(viewChangeTimeoutSec*1000)
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-e", str(True)
             ]
 

--- a/tests/apollo/test_skvbc_time_service.py
+++ b/tests/apollo/test_skvbc_time_service.py
@@ -37,6 +37,10 @@ def start_replica_cmd(builddir, replica_id, time_service_enabled='1'):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path, 
             "-k", KEY_FILE_PREFIX,
@@ -44,6 +48,7 @@ def start_replica_cmd(builddir, replica_id, time_service_enabled='1'):
             "-s", statusTimerMilli,
             "-e", str(True),
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-f", time_service_enabled 
             ]
 

--- a/tests/apollo/test_skvbc_view_change.py
+++ b/tests/apollo/test_skvbc_view_change.py
@@ -32,12 +32,17 @@ def start_replica_cmd(builddir, replica_id):
     """
     statusTimerMilli = "500"
     viewChangeTimeoutMilli = "10000"
+    if os.environ.get('BLOCKCHAIN_VERSION', default="1").lower() == "4" :
+        blockchain_version = "4"
+    else :
+        blockchain_version = "1"
     path = os.path.join(builddir, "tests", "simpleKVBC", "TesterReplica", "skvbc_replica")
     return [path,
             "-k", KEY_FILE_PREFIX,
             "-i", str(replica_id),
             "-s", statusTimerMilli,
             "-v", viewChangeTimeoutMilli,
+            "-V", blockchain_version,
             "-e", str(True)
             ]
 


### PR DESCRIPTION
* **Problem Overview**  
   Changing all the test cases so that apollo test cases can run for both versions.
* **Testing Done**  
  Running all testcases for v1 and v4, this is only for testing purposes. This might increase the build time significantly.
